### PR TITLE
prep for pypi upload

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include AUTHORS.rst
+include CONTRIBUTING.rst
+include HISTORY.rst
+include LICENSE
+include README.rst
+
+recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile make.bat

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ from http://www.rfxcom.com/. Works with http://www.home-assistant.io
 Using
 =====
 
-Install pySerial first::
-	$ sudo easy_install -U pyserial
+Instally via pip
 
+    $ sudo pip install -U pyRFXtrx
 
 After that, see the examples in the examples directory
-
 
 
 Licensing

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-========
-pyRFXtrx
-========
+==========
+ pyRFXtrx
+==========
 
 A Python library to communicate with the RFXtrx family of devices
 from http://www.rfxcom.com/. Works with http://www.home-assistant.io
@@ -11,7 +11,8 @@ Using
 
 Instally via pip
 
-    $ sudo pip install -U pyRFXtrx
+::
+   $ sudo pip install -U pyRFXtrx
 
 After that, see the examples in the examples directory
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ the RFXtrx family of devices from http://www.rfxcom.com/
 See https://github.com/woudt/pyRFXtrx for the latest version.
 
 Copyright (C) 2012  Edwin Woudt <edwin@woudt.nl>
-    
+
 pyRFXtrx is free software: you can redistribute it and/or modify it
 under the terms of the GNU Lesser General Public License as published
 by the Free Software Foundation, either version 3 of the License, or
@@ -23,7 +23,7 @@ If not, see <http://www.gnu.org/licenses/>.
 from setuptools import setup
 
 setup(
-    name = 'RFXtrx',
+    name = 'pyRFXtrx',
     packages = ['RFXtrx'],
     install_requires=['pyserial>=2.7'],
     version = '0.4',


### PR DESCRIPTION
This sets the package name to pyRFXtrx to match the git repository
name for preparation to upload to pypi. It also updates the install
instructions.