### PR TITLE
Fix total power usage calculation in Energy meter

### DIFF
--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -1578,7 +1578,7 @@ class Energy(SensorPacket):
                             (data[9] << 8) + data[10])
         self.totalwatts = ((data[11] * pow(2, 40)) + (data[12] * pow(2, 32)) +
                            (data[13] * pow(2, 24)) + (data[14] << 16) +
-                           (data[15] << 8) + data[15]) / 223.666
+                           (data[15] << 8) + data[16]) / 223.666
 
         if self.subtype == 0x03:
             self.battery = data[17] + 1 * 10

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -18,5 +18,4 @@ class Elec2TestCase(TestCase):
         self.assertEquals(energy.id_string,"2e:b2")
         self.assertEquals(energy.count,3)
         self.assertEquals(energy.currentwatt,692)
-        self.assertEquals(energy.totalwatts,920825.1947099693)
-    
+        self.assertEquals(energy.totalwatts,920824.5195961836)


### PR DESCRIPTION
This pull request fixes what I think is a bug due to a typo in the total watts calculation for energy meters.