### PR TITLE
Add commands to Lighning4 class

### DIFF
--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -605,6 +605,18 @@ class Lighting4(Packet):
     """
     Mapping of numeric subtype values to strings, used in type_string
     """
+    COMMANDS = {0x00: 'Off',
+                0x01: 'On',
+                0x02: 'Off',
+                0x03: 'On',
+                0x04: 'Off',
+                0x05: 'On',
+                0x07: 'On',
+                0x09: 'On',
+                0x0c: 'On'}
+    """
+    Mapping of command numeric values to strings, used for cmnd_string
+    """
 
     def __str__(self):
         return ("Lighting4 [subtype={0}, seqnbr={1}, cmd={2}, pulse={3}, " +
@@ -688,7 +700,10 @@ class Lighting4(Packet):
             self.type_string = self._UNKNOWN_TYPE.format(self.packettype,
                                                          self.subtype)
         if self.cmd is not None:
-            self.cmnd_string = "{0:#04x}".format(self.cmd)
+            if self.cmd2 in self.COMMANDS:
+                self.cmnd_string = self.COMMANDS[self.cmd2]
+            else:
+                self.cmnd_string = self._UNKNOWN_CMND.format(self.cmd2)
 
 
 ###############################################################################

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -58,14 +58,14 @@ class CoreTestCase(TestCase):
         event.device.send_off(core.transport)
         self.assertRaises(ValueError,event.device.send_dim,core.transport,50)
 
-        # Lighting4, not supported yet
+        # Lighting4
         bytes_array = [0x09, 0x13, 0x00, 0x2a, 0x12, 0x34, 0x56, 0x01, 0x5e, 0x70]
         event = core.transport.parse(bytes_array)
         self.assertEquals(RFXtrx.ControlEvent, type(event))
         self.assertEquals(RFXtrx.LightingDevice, type(event.device))
-       # event.device.send_on(core.transport)
-       # event.device.send_off(core.transport)
-       # self.assertRaises(ValueError,event.device.send_dim,core.transport,50)
+        event.device.send_on(core.transport)
+        event.device.send_off(core.transport)
+        self.assertRaises(ValueError,event.device.send_dim,core.transport,50)
 
         # Lighting5, subtype0
         bytes_array = bytearray(b'\x0A\x14\x00\xAD\xF3\x94\xAB\x01\x10\x00\x60')


### PR DESCRIPTION
Adds commands for PT2262 Chip devices.
Ref: https://github.com/Speederc/openhab/blob/be2ebe0d590dc46e8ba1587039aa8d14bbd9e7dd/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4Message.java