### PR TITLE
Support ELEC1 protocol - OWL CM113 / Electrisave / cent-a-meter

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -333,6 +333,15 @@ class SensorEvent(RFXtrxEvent):
             self.values['Energy usage'] = pkt.currentwatt
             self.values['Total usage'] = pkt.totalwatts
             self.values['Count'] = pkt.count
+        if isinstance(pkt, lowlevel.Energy1):
+            self.values['Current Ch. 1'] = pkt.currentamps1
+            self.values['Current Ch. 2'] = pkt.currentamps2
+            self.values['Current Ch. 3'] = pkt.currentamps3
+            # CM113/ELEC1 doesn't have a 'total usage' counter, so provide an
+            # aggregated virtual value
+            self.values['Total usage'] = (pkt.currentamps1 + pkt.currentamps2
+                                          + pkt.currentamps3)
+            self.values['Count'] = pkt.count
         if isinstance(pkt, lowlevel.Energy4):
             self.values['Current Ch. 1'] = pkt.currentamps1
             self.values['Current Ch. 2'] = pkt.currentamps2

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,6 +1,27 @@
 from unittest import TestCase
 
 import RFXtrx
+
+class Elec1TestCase(TestCase):
+
+    def setUp(self):
+        self.data = bytearray(b'\x0D\x59\x01\xA7\x56\x00\x0A'
+                              b'\x00\x07\x00\x00\x0B\x07\x69')
+        self.parser = RFXtrx.lowlevel.Energy1()
+
+    def test_parse_bytes(self):
+
+        energy = RFXtrx.lowlevel.parse(self.data)
+        print(energy)
+        self.assertEquals(energy.type_string,"ELEC1")
+        self.assertEquals(energy.seqnbr,167)
+        self.assertEquals(energy.id_string,"56:00")
+        self.assertEquals(energy.count,10)
+        self.assertEquals(energy.currentamps1,0.7)
+        self.assertEquals(energy.currentamps2,0)
+        self.assertEquals(energy.currentamps3,282.3)
+        self.assertEquals(energy.rssi,6)
+        self.assertEquals(energy.battery,9)
         
 class Elec2TestCase(TestCase):
 


### PR DESCRIPTION
Provide protocol support for the ELEC1 packet format. Based on RFXComCurrentMessage.java from OpenHAB.

This has been tested to work with an OWL CM113 device. The only potentially contentious part is the addition of the virtual 'Total usage' variable being returned. As this value is not exposed in the packet directly (as with the total watt-hour settings in Energy/Energy4) I've added this to make it easier to integrate with home-assistant (adding a single type rather than messing around with template sensors, which doesn't seem to work very well).