### PR TITLE
Keep raw packet around in SensorEvent

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -303,6 +303,7 @@ class SensorEvent(RFXtrxEvent):
         super(SensorEvent, self).__init__(device)
 
         self.values = {}
+        self.pkt = pkt
         if isinstance(pkt, lowlevel.RfxMeter):
             self.values['Counter value'] = pkt.value
         if isinstance(pkt, lowlevel.Temp) \


### PR DESCRIPTION
the pyRFXtrx library is extremely useful for parsing RFXtrx data even
if not using the event loop in the library. However, in order to do
this effectively it's really useful to have access to the raw packet,
especially as this provides all the lowlevel type information.