### PR TITLE
Add ASA blinds support

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -75,7 +75,7 @@ class RfyDevice(RFXtrxDevice):
         """ Send a 'Close' command using the given transport """
         pkt = lowlevel.Rfy()
         pkt.set_transmit(
-            0x00,
+            self.subtype,
             self.cmndseqnbr,
             self.id_combined,
             self.unitcode,
@@ -88,7 +88,7 @@ class RfyDevice(RFXtrxDevice):
         """ Send an 'Open' command using the given transport """
         pkt = lowlevel.Rfy()
         pkt.set_transmit(
-            0x00,
+            self.subtype,
             self.cmndseqnbr,
             self.id_combined,
             self.unitcode,
@@ -101,7 +101,7 @@ class RfyDevice(RFXtrxDevice):
         """ Send a 'Stop' command using the given transport """
         pkt = lowlevel.Rfy()
         pkt.set_transmit(
-            0x00,
+            self.subtype,
             self.cmndseqnbr,
             self.id_combined,
             self.unitcode,

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -1987,7 +1987,9 @@ class Rfy(Packet):
     """
     Data class for the Rfy packet type
     """
-    TYPES = {0x00: 'Rfy'}
+    TYPES = {0x00: 'Rfy',
+             0x01: 'Rfy Extended',
+             0x03: 'ASA'}
     """
     Mapping of numeric subtype values to strings, used in type_string
     """

--- a/tests/test_rfy.py
+++ b/tests/test_rfy.py
@@ -38,4 +38,9 @@ class RfyTestCase(TestCase):
 
         rfy = RFXtrx.lowlevel.parse(bytearray(b'\x08\x1A\x01\x00\x0A\x00\x01\x01\x05'))
         self.assertEquals(rfy.cmnd_string, "Unknown command (0x05)")
-        self.assertEquals(rfy.type_string, "Unknown type (0x1a/0x01)")
+        self.assertEquals(rfy.type_string, "Rfy Extended")
+
+        rfy = RFXtrx.get_device(0x1A,3,'0a0001:2')
+        self.assertEqual(rfy.subtype, 3)
+        self.assertEquals(rfy.__str__(), "<class 'RFXtrx.RfyDevice'> type='ASA' id='0a0001:2'")
+        

--- a/tests/test_rfy.py
+++ b/tests/test_rfy.py
@@ -40,6 +40,10 @@ class RfyTestCase(TestCase):
         self.assertEquals(rfy.cmnd_string, "Unknown command (0x05)")
         self.assertEquals(rfy.type_string, "Rfy Extended")
 
+        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x08\x1A\x02\x00\x0A\x00\x01\x01\x05'))
+        self.assertEquals(rfy.cmnd_string, "Unknown command (0x05)")
+        self.assertEquals(rfy.type_string, "Unknown type (0x1a/0x02)")
+        
         rfy = RFXtrx.get_device(0x1A,3,'0a0001:2')
         self.assertEqual(rfy.subtype, 3)
         self.assertEquals(rfy.__str__(), "<class 'RFXtrx.RfyDevice'> type='ASA' id='0a0001:2'")


### PR DESCRIPTION
ASA blinds use a subtype of the Rfy protocol. (subtype 3)
While the subtype was set, send_open, send_stop, and send_close always sent a subtype of 0. 

After setting the subtype to self.subtype, my blinds work. 
Also added descriptive strings (subtype 1 Rfy Extended, subtype 3 ASA) and updated tests
