### PR TITLE
Add reconnection mechanism in read loop

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -596,7 +596,7 @@ class PySerialTransport(RFXtrxTransport):
                 import time
                 try:
                     self.connect()
-                except:
+                except serial.serialutil.SerialException:
                     time.sleep(5)
             if not data or data == '\x00':
                 continue

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -572,7 +572,7 @@ class PySerialTransport(RFXtrxTransport):
         self._run_event = threading.Event()
         self._run_event.set()
         self.connect()
-        
+
     def connect(self):
         """ Open a serial connexion """
         try:
@@ -593,14 +593,10 @@ class PySerialTransport(RFXtrxTransport):
             except TypeError:
                 continue
             except serial.serialutil.SerialException:
-                if self.debug:
-                    print("ERROR: the serial port is not available anymore, try to reconnect")
                 import time
                 try:
                     self.connect()
                 except:
-                    if self.debug:
-                        print("ERROR: reconnection failed, wait 5 seconds then retry")
                     time.sleep(5)
             if not data or data == '\x00':
                 continue


### PR DESCRIPTION
After a SerialException (documented as  "In case the device can not be found or can not be configured." in pyserial) in the main read loop, the transport layer will try to reconnect every 5 sec until it succeeds. Tested on my install of hass, works fine for me.