### PR TITLE
Add support for disable/enable sun automation

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -160,6 +160,32 @@ class RfyDevice(RFXtrxDevice):
         transport.send(pkt.data)
 
 
+    def send_on(self, transport):
+        """ Send an 'Enable Sun Automation' command using the given transport """
+        pkt = lowlevel.Rfy()
+        pkt.set_transmit(
+            self.subtype,
+            self.cmndseqnbr,
+            self.id_combined,
+            self.unitcode,
+            0x13
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
+    def send_off(self, transport):
+        """ Send an 'Disable Sun Automation' command using the given transport """
+        pkt = lowlevel.Rfy()
+        pkt.set_transmit(
+            self.subtype,
+            self.cmndseqnbr,
+            self.id_combined,
+            self.unitcode,
+            0x14
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
 class LightingDevice(RFXtrxDevice):
     """ Concrete class for a control device """
 

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2348,7 +2348,9 @@ class Rfy(Packet):
 
     COMMANDS = {0x00: 'Stop',
                 0x01: 'Up',
-                0x03: 'Down'}
+                0x03: 'Down',
+                0x13: 'Enable sun automation',
+                0x14: 'Disable sun automation'}
     """
     Mapping of command numeric values to strings, used for cmnd_string
     """


### PR DESCRIPTION
This enables the possibility to disable and enable
sun automation for rfy devices. Can be added as a
switch in HASS that will call the on and off function.