### PR TITLE
WIP: add fan support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ matrix:
     env: TOXENV=py36
   - python: '3.5'
     env: TOXENV=lint
-  - python: "nightly"
+  - python: "3.6"
     env: TOXENV=py36
+  - python: "3.7"
+    env: TOXENV=py37
+  - python: "3.8-dev"
+    env: TOXENV=py38
 
   allow_failures:
   - python: 'nightly'

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -153,7 +153,6 @@ class FanDevice(RFXtrxDevice):
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)
 
-
     def send_low(self, transport):
         """ Send a 'Low speed' command using the given transport """
 

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -121,24 +121,34 @@ class FanDevice(RFXtrxDevice):
 
     def send_high(self, transport):
         """ Send a 'High speed' command using the given transport """
+
+        # TODO: cmnd depends on the subtype, so this currently only works for
+        # Lucci Air AC type devices (0x02)
+        cmnd = 0x01
+
         pkt = lowlevel.Fan()
         pkt.set_transmit(
             self.subtype,
             self.cmndseqnbr,
             self.id_combined,
-            0x01 # TODO: this depends on the subtype, currently only works for Lucci Air AC
+            cmnd
         )
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)
 
     def send_medium(self, transport):
         """ Send a 'Medium speed' command using the given transport """
+
+        # TODO: cmnd depends on the subtype, so this currently only works for
+        # Lucci Air AC type devices (0x02)
+        cmnd = 0x02
+
         pkt = lowlevel.Fan()
         pkt.set_transmit(
             self.subtype,
             self.cmndseqnbr,
             self.id_combined,
-            0x02 # TODO: this depends on the subtype, currently only works for Lucci Air AC
+            cmnd
         )
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)
@@ -146,36 +156,52 @@ class FanDevice(RFXtrxDevice):
 
     def send_low(self, transport):
         """ Send a 'Low speed' command using the given transport """
+
+        # TODO: cmnd depends on the subtype, so this currently only works for
+        # Lucci Air AC type devices (0x02)
+        cmnd = 0x03
+
         pkt = lowlevel.Fan()
         pkt.set_transmit(
             self.subtype,
             self.cmndseqnbr,
             self.id_combined,
-            0x03 # TODO: this depends on the subtype, currently only works for Lucci Air AC
+            cmnd
         )
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)
 
     def send_off(self, transport):
         """ Send a 'Light on' command """
+
+        # TODO: cmnd depends on the subtype, so this currently only works for
+        # Lucci Air AC type devices (0x02)
+        cmnd = 0x04
+
         pkt = lowlevel.Fan()
         pkt.set_transmit(
             self.subtype,
             self.cmndseqnbr,
             self.id_combined,
-            0x04 # TODO: this depends on the subtype, currently only works for Lucci Air AC
+            cmnd
         )
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)
 
     def send_onoff(self, transport, turn_on):
         """ Send a 'Light on' or 'Light off' command """
+
+        # TODO: cmnd depends on the subtype, so this currently only works for
+        # Lucci Air AC type devices (0x02), which only supports light toggling
+        # (no known state) so turn_on is meaningless here.
+        cmnd = 0x05
+
         pkt = lowlevel.Fan()
         pkt.set_transmit(
             self.subtype,
             self.cmndseqnbr,
             self.id_combined,
-            0x05 # TODO: this depends on the subtype, currently only works for Lucci Air AC, which only supports light toggling (no known state)
+            cmnd
         )
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2503,10 +2503,12 @@ class Fan(Packet):
         self.id2 = id_combined >> 8 & 0xff
         self.id3 = id_combined & 0xff
         self.cmnd = cmnd
+
+        # Note: there's always a trailing zero in sniffed fan packets
         self.data = bytearray([self.packetlength, self.packettype,
                                self.subtype, self.seqnbr,
                                self.id1, self.id2, self.id3,
-                               self.cmnd, 0x00]) # There's always a trailing zero in sniffed packets
+                               self.cmnd, 0x00])
 
         self._set_strings()
 
@@ -2516,14 +2518,16 @@ class Fan(Packet):
 
         if self.subtype in self.TYPES:
             self.type_string = self.TYPES[self.subtype]
+            cmnds = self.COMMANDS[self.subtype]
         else:
             # Degrade nicely for yet unknown subtypes
             self.type_string = self._UNKNOWN_TYPE.format(self.packettype,
                                                          self.subtype)
+            cmnds = []
 
         if self.cmnd is not None:
-            if self.subtype in self.TYPES and self.cmnd in self.COMMANDS[self.subtype]:
-                self.cmnd_string = self.COMMANDS[self.subtype][self.cmnd]
+            if self.cmnd in cmnds:
+                self.cmnd_string = cmnds[self.cmnd]
             else:
                 self.cmnd_string = self._UNKNOWN_CMND.format(self.cmnd)
 

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -35,12 +35,15 @@ def main():
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
-    core = RFXtrx.Core(rfxcom_device, print_callback, debug=True, modes=modes_list)
+    conn = RFXtrx.Connect(rfxcom_device, print_callback, debug=True, modes=modes_list)
 
-    print (core)
-    while True:
-        print(core.sensors())
-        time.sleep(2)
+    try:
+        print (conn)
+        while True:
+            print(conn.sensors())
+            time.sleep(2)
+    finally:
+        conn.close_connection()
 
 if __name__ == "__main__":
     try:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -213,6 +213,18 @@ class CoreTestCase(TestCase):
         event.device.send_close(core.transport)
         event.device.send_stop(core.transport)
 
+        #Fan
+        bytes_array = bytearray(b'\x08\x17\x02\x00\x00\x00\x01\x03\x00')
+        event = core.transport.receive(bytes_array)
+        self.assertEquals(RFXtrx.ControlEvent, type(event))
+        self.assertEquals(event.__str__(),"<class 'RFXtrx.ControlEvent'> device=[<class 'RFXtrx.FanDevice'> type='Lucci Air AC' id='000001'] values=[('Command', 'LOW')]")
+        event.device.send_high(core.transport)
+        event.device.send_medium(core.transport)
+        event.device.send_low(core.transport)
+        event.device.send_off(core.transport)
+        event.device.send_onoff(core.transport, True)
+        event.device.send_onoff(core.transport, False)
+
         #Rfy
         bytes_array = bytearray(b'\x08\x1A\x00\x00\x0A\x00\x01\x01\x03')
         event= core.transport.receive(bytes_array)

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+
+import RFXtrx
+
+
+class FanTestCase(TestCase):
+    def test_parse_bytes(self):
+
+        fan = RFXtrx.lowlevel.parse(bytearray(b'\x08\x17\x00\x00\x0A\x00\x01\x03\x00'))
+        self.assertEqual(fan.__repr__(), "Fan [subtype=0, seqnbr=0, id=0a0001, cmnd=Learn]")
+        self.assertEqual(fan.packetlength, 8)
+        self.assertEqual(fan.subtype, 0)
+        self.assertEqual(fan.type_string, "Siemens SF01")
+        self.assertEqual(fan.seqnbr, 0)
+        self.assertEqual(fan.id_string, "0a0001")
+        self.assertEqual(fan.cmnd, 3)
+        self.assertEqual(fan.cmnd_string, "Learn")
+
+        fan = RFXtrx.lowlevel.Fan()
+        fan.set_transmit(0, 0, 0x0a0001, 3)
+        self.assertEqual(fan.__repr__(), "Fan [subtype=0, seqnbr=0, id=0a0001, cmnd=Learn]")
+        self.assertEqual(fan.packetlength, 8)
+        self.assertEqual(fan.subtype, 0)
+        self.assertEqual(fan.type_string, "Siemens SF01")
+        self.assertEqual(fan.seqnbr, 0)
+        self.assertEqual(fan.id_string, "0a0001")
+        self.assertEqual(fan.cmnd, 3)
+        self.assertEqual(fan.cmnd_string, "Learn")
+
+        fan = RFXtrx.lowlevel.Fan()
+        fan.parse_id(0, "0a0001")
+        self.assertEqual(fan.id_string, "0a0001")
+        self.assertEqual(fan.id_combined, 0x0a0001)
+        self.assertRaises(ValueError, fan.parse_id, 0, "AA")
+
+        fan = RFXtrx.get_device(0x17, 0, "0a0001")
+        self.assertEqual(fan.__str__(), "<class 'RFXtrx.FanDevice'> type='Siemens SF01' id='0a0001'")
+        self.assertEqual(fan.id_combined, 0x0a0001)
+
+        fan = RFXtrx.lowlevel.parse(bytearray(b'\x08\x17\x02\x00\x0A\x00\x01\x06\x00'))
+        self.assertEqual(fan.cmnd_string, "Unknown command (0x06)")
+        self.assertEqual(fan.type_string, "Lucci Air AC")
+
+        fan = RFXtrx.lowlevel.parse(bytearray(b'\x08\x17\x0A\x00\x0A\x00\x01\x05\x00'))
+        self.assertEqual(fan.cmnd_string, "Unknown command (0x05)")
+        self.assertEqual(fan.type_string, "Unknown type (0x17/0x0a)")
+
+        fan = RFXtrx.get_device(0x17,3,'0a0001')
+        self.assertEqual(fan.subtype, 3)
+        self.assertEqual(fan.__str__(), "<class 'RFXtrx.FanDevice'> type='SEAV TXS4' id='0a0001'")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, lint
+envlist = py34, py35, py36, py37, py38, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This PR intends to implement support for all fan types and commands supported by RFXtrx433XL with 1037 firmware (these were sniffed from USB traffic generated by the RFXmngr Windows app version 19.0.0.16).

This is marked as _Work In Progress_ because:
- it currently only partially implements commands for `Lucci Air AC` type devices,
- it wasn't tested with Home Assistant yet.

I submitted early to get a first pass of CI checks, and better yet, an early review.

Should address https://github.com/Danielhiversen/pyRFXtrx/issues/79