### PR TITLE
Adds network to pyRFXtrx 

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -25,8 +25,8 @@ from __future__ import print_function
 
 from time import sleep
 import threading
-import serial
 import socket
+import serial
 from . import lowlevel
 
 
@@ -654,7 +654,7 @@ class PySerialTransport(RFXtrxTransport):
             if not data or data == '\x00':
                 continue
             pkt = bytearray(data)
-            data = self.serial.read(pkt[0])         # potential race condition? incomplete data if timeout before all bytes are read.
+            data = self.serial.read(pkt[0])
             pkt.extend(bytearray(data))
             if self.debug:
                 print("RFXTRX: Recv: " +

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -31,12 +31,13 @@ def main():
     if len(sys.argv) >= 2:
         rfxcom_device = sys.argv[1]
     else:
-        rfxcom_device = '/dev/ttyUSB0'
+        rfxcom_device = ('192.168.2.6', 10001)
+        # rfxcom_device = '/dev/ttyUSB0'
     # Start docker with this parameter:       --device=/dev/ttyUSB0
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
-    core = RFXtrx.Core(rfxcom_device, print_callback, debug=True, modes=modes_list)
+    core = RFXtrx.Core(rfxcom_device, print_callback, transport_protocol=RFXtrx.PyNetworkTransport, debug=True, modes=modes_list)
 
     print (core)
     while True:

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -31,13 +31,11 @@ def main():
     if len(sys.argv) >= 2:
         rfxcom_device = sys.argv[1]
     else:
-        rfxcom_device = ('192.168.2.6', 10001)
-        # rfxcom_device = '/dev/ttyUSB0'
-    # Start docker with this parameter:       --device=/dev/ttyUSB0
+        rfxcom_device = '/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0'
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
-    core = RFXtrx.Core(rfxcom_device, print_callback, transport_protocol=RFXtrx.PyNetworkTransport, debug=True, modes=modes_list)
+    core = RFXtrx.Core(rfxcom_device, print_callback, debug=True, modes=modes_list)
 
     print (core)
     while True:

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -32,6 +32,7 @@ def main():
         rfxcom_device = sys.argv[1]
     else:
         rfxcom_device = '/dev/ttyUSB0'
+    # Start docker with this parameter:       --device=/dev/ttyUSB0
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -31,7 +31,7 @@ def main():
     if len(sys.argv) >= 2:
         rfxcom_device = sys.argv[1]
     else:
-        rfxcom_device = '/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0'
+        rfxcom_device = '/dev/ttyUSB0'
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)


### PR DESCRIPTION
As documented in issue https://github.com/Danielhiversen/pyRFXtrx/issues/84

This PR adds network support to pyRFXtrx  
so it can be used by a device that is on the same network, or simply when USB is not favorable or available.

My problem was i have my RFXCom device on a Raspberry Pi near the power meter on the ground floor, but run my Home Assistant in a VM on the server in the attic. Most devices i use in Home Assistant already allow network support.

Usage: (minimal example)
```python
RFXtrx.Core(('192.168.0.123', 10001), transport_protocol=RFXtrx.PyNetworkTransport)
```

To expose your RFXCom via network, use [ser2net](https://www.jpaul.me/2019/01/how-to-build-a-raspberry-pi-serial-console-server-with-ser2net/) with this config:
```
# RFXTRX433XL
10001:raw:600:/dev/ttyUSB1:38400 8DATABITS NONE 1STOPBIT
```
The RFXmgmr tool should be able to connect to the above.

When i made a PR to Home Assistant to allow usage, i'm going to reference it here.