### PR TITLE
Support control of chime devices

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -334,6 +334,7 @@ class LightingDevice(RFXtrxDevice):
         else:
             raise ValueError("Unsupported packettype")
 
+
 class ChimeDevice(RFXtrxDevice):
     """ Concrete class for a control device """
     def __init__(self, pkt):
@@ -346,6 +347,7 @@ class ChimeDevice(RFXtrxDevice):
         pkt = lowlevel.Chime()
         pkt.set_transmit(self.subtype, 0, self.id1, self.id2, sound)
         transport.send(pkt.data)
+
 
 ###############################################################################
 # get_devide method
@@ -815,6 +817,7 @@ class DummyTransport(RFXtrxTransport):
     def close(self):
         """Close."""
         self._close_event.set()
+
 
 class DummyTransport2(PySerialTransport):
     """ Dummy transport for testing purposes """

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -342,7 +342,7 @@ class ChimeDevice(RFXtrxDevice):
         self.id1 = pkt.id1
         self.id2 = pkt.id2
 
-    def send_sound(self, transport, sound):
+    def send_chime(self, transport, sound):
         """Trigger a chime sound on device."""
         pkt = lowlevel.Chime()
         pkt.set_transmit(self.subtype, 0, self.id1, self.id2, sound)

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -458,8 +458,6 @@ class SensorEvent(RFXtrxEvent):
             self.values['Current'] = pkt.currentamps
             self.values['Energy usage'] = pkt.currentwatt
             self.values['Total usage'] = pkt.totalwatthours
-        if isinstance(pkt, lowlevel.Chime):
-            self.values['Sound'] = pkt.sound
         if isinstance(pkt, lowlevel.Security1):
             self.values['Sensor Status'] = pkt.security1_status_string
         if not isinstance(pkt, (lowlevel.Energy5, lowlevel.RfxMeter)):
@@ -507,6 +505,9 @@ class ControlEvent(RFXtrxEvent):
         if isinstance(pkt, lowlevel.Lighting5) \
                 and pkt.cmnd in [0x0d, 0x0e, 0x0f]:
             self.device.known_to_be_rollershutter = True
+
+        if isinstance(pkt, lowlevel.Chime):
+            self.values['Sound'] = pkt.sound
 
         if pkt.rssi is not None:
             self.values['Rssi numeric'] = pkt.rssi

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -334,6 +334,18 @@ class LightingDevice(RFXtrxDevice):
         else:
             raise ValueError("Unsupported packettype")
 
+class ChimeDevice(RFXtrxDevice):
+    """ Concrete class for a control device """
+    def __init__(self, pkt):
+        super(ChimeDevice, self).__init__(pkt)
+        self.id1 = pkt.id1
+        self.id2 = pkt.id2
+
+    def send_sound(self, transport, sound):
+        """Trigger a chime sound on device."""
+        pkt = lowlevel.Chime()
+        pkt.set_transmit(self.subtype, 0, self.id1, self.id2, sound)
+        transport.send(pkt.data)
 
 ###############################################################################
 # get_devide method
@@ -367,6 +379,9 @@ def get_device(packettype, subtype, id_string):
         pkt = lowlevel.Lighting6()
         pkt.parse_id(subtype, id_string)
         return LightingDevice(pkt)
+    if packettype == 0x16:
+        pkt = lowlevel.Chime()
+        pkt.parse_id(subtype, id_string)
     if packettype == 0x19:  # RollerTrol
         pkt = lowlevel.RollerTrol()
         pkt.parse_id(subtype, id_string)
@@ -486,6 +501,8 @@ class ControlEvent(RFXtrxEvent):
             device = RollerTrolDevice(pkt)
         elif isinstance(pkt, lowlevel.Rfy):
             device = RfyDevice(pkt)
+        elif isinstance(pkt, lowlevel.Chime):
+            device = ChimeDevice(pkt)
         else:
             device = RFXtrxDevice(pkt)
         super(ControlEvent, self).__init__(device)

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -379,9 +379,10 @@ def get_device(packettype, subtype, id_string):
         pkt = lowlevel.Lighting6()
         pkt.parse_id(subtype, id_string)
         return LightingDevice(pkt)
-    if packettype == 0x16:
+    if packettype == 0x16:  # Chime
         pkt = lowlevel.Chime()
         pkt.parse_id(subtype, id_string)
+        return ChimeDevice(pkt)
     if packettype == 0x19:  # RollerTrol
         pkt = lowlevel.RollerTrol()
         pkt.parse_id(subtype, id_string)

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2209,7 +2209,7 @@ class Chime(Packet):
             self.packettype = 0x16
             self.subtype = subtype
             self.id1 = int(id_string[:2], 16)
-            self.id2 = int(id_string[2:4], 16)
+            self.id2 = int(id_string[3:5], 16)
             self._set_strings()
         except ValueError:
             raise ValueError("Invalid id_string")

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2172,7 +2172,7 @@ class Energy5(SensorPacket):
 ###############################################################################
 
 
-class Chime(SensorPacket):
+class Chime(Packet):
     """
     Data class for the Chime packet type
     """
@@ -2200,6 +2200,8 @@ class Chime(SensorPacket):
         self.sound = None
         self.battery = None
         self.rssi = None
+        self.cmnd = None
+        self.cmnd_string = None
 
     def load_receive(self, data):
         """Load data from a bytearray"""
@@ -2225,6 +2227,7 @@ class Chime(SensorPacket):
             # Degrade nicely for yet unknown subtypes
             self.type_string = self._UNKNOWN_TYPE.format(self.packettype,
                                                          self.subtype)
+        self.cmnd_string = "Chime"
 
 ###############################################################################
 # Security1 class

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2218,6 +2218,23 @@ class Chime(Packet):
         self.rssi = self.rssi_byte >> 4
         self._set_strings()
 
+    def set_transmit(self, subtype, seqnbr, id1, id2, sound):
+        """Load data from individual data fields"""
+        self.packetlength = 0x07
+        self.packettype = 0x16
+        self.subtype = subtype
+        self.seqnbr = seqnbr
+        self.id1 = id1
+        self.id2 = id2
+        self.sound = sound
+        self.battery = 0
+        self.rssi = 0
+        self.rssi_byte = (self.rssi << 4) | self.battery
+        self.data = bytearray([self.packetlength, self.packettype,
+                               self.subtype, self.seqnbr,
+                               self.id1, self.id2, self.sound,
+                               self.rssi_byte])
+
     def _set_strings(self):
         """Translate loaded numeric values into convenience strings"""
         self.id_string = "{0:02x}:{1:02x}".format(self.id1, self.id2)

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2203,6 +2203,19 @@ class Chime(Packet):
         self.cmnd = None
         self.cmnd_string = None
 
+    def parse_id(self, subtype, id_string):
+        """Parse a string id into individual components"""
+        try:
+            self.packettype = 0x16
+            self.subtype = subtype
+            self.id1 = int(id_string[:2], 16)
+            self.id2 = int(id_string[2:4], 16)
+            self._set_strings()
+        except ValueError:
+            raise ValueError("Invalid id_string")
+        if self.id_string != id_string:
+            raise ValueError("Invalid id_string")
+
     def load_receive(self, data):
         """Load data from a bytearray"""
         self.data = data

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -233,6 +233,7 @@ class CoreTestCase(TestCase):
         event = core.transport.parse(bytes_array)
         self.assertEquals(RFXtrx.ControlEvent, type(event))
         self.assertEquals(event.__str__(),"<class 'RFXtrx.ControlEvent'> device=[<class 'RFXtrx.ChimeDevice'> type='Byron SX' id='00:00'] values=[('Command', 'Chime'), ('Rssi numeric', 0), ('Sound', 0)]")
+        event.device.send_chime(core.transport, 1)
 
         #security1
         bytes_array = [0x0a, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -231,8 +231,8 @@ class CoreTestCase(TestCase):
         #Chime
         bytes_array = [0x0a, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         event = core.transport.parse(bytes_array)
-        self.assertEquals(RFXtrx.SensorEvent, type(event))
-        self.assertEquals(event.__str__(),"<class 'RFXtrx.SensorEvent'> device=[<class 'RFXtrx.RFXtrxDevice'> type='Byron SX' id='00:00'] values=[('Battery numeric', 0), ('Rssi numeric', 0), ('Sound', 0)]")
+        self.assertEquals(RFXtrx.ControlEvent, type(event))
+        self.assertEquals(event.__str__(),"<class 'RFXtrx.ControlEvent'> device=[<class 'RFXtrx.ChimeDevice'> type='Byron SX' id='00:00'] values=[('Command', 'Chime'), ('Rssi numeric', 0), ('Sound', 0)]")
 
         #security1
         bytes_array = [0x0a, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,7 @@ class CoreTestCase(TestCase):
     def test_constructor(self):
         global num_calbacks
         core = RFXtrx.Core(self.path, event_callback=_callback, debug=False,transport_protocol=RFXtrx.DummyTransport2)
-        while num_calbacks < 5:
+        while num_calbacks < 6:
             time.sleep(0.1)
 
         self.assertEquals(len(core.sensors()),2)
@@ -384,6 +384,7 @@ class CoreTestCase(TestCase):
     def test_set_recmodes(self):
         core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, 
                               transport_protocol=RFXtrx.DummyTransport)
+        time.sleep(0.2)
         self.assertEquals(None, core._modes)
 
         modes = ['ac', 'arc', 'hideki', 'homeeasy', 'keeloq', 'lacrosse', 'oregon', 'rsl', 'x10']
@@ -404,6 +405,7 @@ class CoreTestCase(TestCase):
 
     def test_receive(self):
         core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, transport_protocol=RFXtrx.DummyTransport)
+        time.sleep(0.2)
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event= core.transport.receive(bytes_array)


### PR DESCRIPTION
This switches chime devices to ControlEvent and add support for sending

Also corrections for dummy transports that maxed out CPU during test runs are added.