### PR TITLE
Drop debug argument and rely on normal logging functions

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -36,6 +36,7 @@ from . import lowlevel
 
 _LOGGER = logging.getLogger(__name__)
 
+
 ###############################################################################
 # RFXtrxDevice class
 ###############################################################################
@@ -681,7 +682,7 @@ class PySerialTransport(RFXtrxTransport):
             data = self.serial.read(pkt[0])
             pkt.extend(bytearray(data))
             _LOGGER.debug(
-                "Recv: " +
+                "Recv: %s",
                 " ".join("0x{0:02x}".format(x) for x in pkt)
             )
             return self.parse(pkt)
@@ -695,7 +696,7 @@ class PySerialTransport(RFXtrxTransport):
         else:
             raise ValueError("Invalid type")
         _LOGGER.debug(
-            "Send: " +
+            "Send: %s",
             " ".join("0x{0:02x}".format(x) for x in pkt)
         )
         self.serial.write(pkt)
@@ -756,7 +757,7 @@ class PyNetworkTransport(RFXtrxTransport):
                 data = self.sock.recv(pkt[0])
                 pkt.extend(bytearray(data))
             _LOGGER.debug(
-                "Recv: " +
+                "Recv: %s",
                 " ".join("0x{0:02x}".format(x) for x in pkt)
             )
             return self.parse(pkt)
@@ -770,7 +771,7 @@ class PyNetworkTransport(RFXtrxTransport):
         else:
             raise ValueError("Invalid type")
         _LOGGER.debug(
-            "Send: " +
+            "Send: %s",
             " ".join("0x{0:02x}".format(x) for x in pkt)
         )
         self.sock.send(pkt)
@@ -801,7 +802,7 @@ class DummyTransport(RFXtrxTransport):
             return None
         pkt = bytearray(data)
         _LOGGER.debug(
-            "Recv: " +
+            "Recv: %s",
             " ".join("0x{0:02x}".format(x) for x in pkt)
         )
         return self.parse(pkt)
@@ -810,12 +811,12 @@ class DummyTransport(RFXtrxTransport):
         """ Emulate a receive by parsing the given data """
         return self.receive(data)
 
-    def send(self, data):
+    def send(self, data):  # pylint: disable=R0201
         """ Emulate a send by doing nothing (except printing debug info if
             requested) """
         pkt = bytearray(data)
         _LOGGER.debug(
-            "Send: " +
+            "Send: %s",
             " ".join("0x{0:02x}".format(x) for x in pkt)
         )
 

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -21,18 +21,20 @@
 This module provides the base implementation for pyRFXtrx
 """
 # pylint: disable=R0903, invalid-name
-from __future__ import print_function
 
 import glob
 import socket
 import threading
 import time
+import logging
+
 from time import sleep
 
 import serial
 
 from . import lowlevel
 
+_LOGGER = logging.getLogger(__name__)
 
 ###############################################################################
 # RFXtrxDevice class
@@ -642,8 +644,7 @@ class RFXtrxTransport:
 class PySerialTransport(RFXtrxTransport):
     """ Implementation of a transport using PySerial """
 
-    def __init__(self, port, debug=False):
-        self.debug = debug
+    def __init__(self, port):
         self.port = port
         self.serial = None
         self._run_event = threading.Event()
@@ -679,9 +680,10 @@ class PySerialTransport(RFXtrxTransport):
             pkt = bytearray(data)
             data = self.serial.read(pkt[0])
             pkt.extend(bytearray(data))
-            if self.debug:
-                print("RFXTRX: Recv: " +
-                      " ".join("0x{0:02x}".format(x) for x in pkt))
+            _LOGGER.debug(
+                "Recv: " +
+                " ".join("0x{0:02x}".format(x) for x in pkt)
+            )
             return self.parse(pkt)
 
     def send(self, data):
@@ -692,9 +694,10 @@ class PySerialTransport(RFXtrxTransport):
             pkt = bytearray(data)
         else:
             raise ValueError("Invalid type")
-        if self.debug:
-            print("RFXTRX: Send: " +
-                  " ".join("0x{0:02x}".format(x) for x in pkt))
+        _LOGGER.debug(
+            "Send: " +
+            " ".join("0x{0:02x}".format(x) for x in pkt)
+        )
         self.serial.write(pkt)
 
     def reset(self):
@@ -717,8 +720,7 @@ class PySerialTransport(RFXtrxTransport):
 class PyNetworkTransport(RFXtrxTransport):
     """ Implementation of a transport using sockets """
 
-    def __init__(self, hostport, debug=False):
-        self.debug = debug
+    def __init__(self, hostport):
         self.hostport = hostport    # must be a (host, port) tuple
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._run_event = threading.Event()
@@ -729,9 +731,9 @@ class PyNetworkTransport(RFXtrxTransport):
         """ Open a socket connection """
         try:
             self.sock.connect(self.hostport)
-            print("RFXTRX: Connected to network socket")
+            _LOGGER.info("Connected to network socket")
         except socket.error:
-            print('RFXTRX: Failed to create socket, check host port config')
+            _LOGGER.error('Failed to create socket, check host port config')
             # This may throw exception for use by caller:
             self.sock.connect(self.hostport)
 
@@ -753,9 +755,10 @@ class PyNetworkTransport(RFXtrxTransport):
             while len(pkt) < pkt[0]:
                 data = self.sock.recv(pkt[0])
                 pkt.extend(bytearray(data))
-            if self.debug:
-                print("RFXTRX: Recv: " +
-                      " ".join("0x{0:02x}".format(x) for x in pkt))
+            _LOGGER.debug(
+                "Recv: " +
+                " ".join("0x{0:02x}".format(x) for x in pkt)
+            )
             return self.parse(pkt)
 
     def send(self, data):
@@ -766,9 +769,10 @@ class PyNetworkTransport(RFXtrxTransport):
             pkt = bytearray(data)
         else:
             raise ValueError("Invalid type")
-        if self.debug:
-            print("RFXTRX: Send: " +
-                  " ".join("0x{0:02x}".format(x) for x in pkt))
+        _LOGGER.debug(
+            "Send: " +
+            " ".join("0x{0:02x}".format(x) for x in pkt)
+        )
         self.sock.send(pkt)
 
     def reset(self):
@@ -786,9 +790,8 @@ class PyNetworkTransport(RFXtrxTransport):
 class DummyTransport(RFXtrxTransport):
     """ Dummy transport for testing purposes """
 
-    def __init__(self, device="", debug=True):
+    def __init__(self, device=""):
         self.device = device
-        self.debug = debug
         self._close_event = threading.Event()
 
     def receive(self, data=None):
@@ -797,9 +800,10 @@ class DummyTransport(RFXtrxTransport):
             self._close_event.wait(0.1)
             return None
         pkt = bytearray(data)
-        if self.debug:
-            print("RFXTRX: Recv: " +
-                  " ".join("0x{0:02x}".format(x) for x in pkt))
+        _LOGGER.debug(
+            "Recv: " +
+            " ".join("0x{0:02x}".format(x) for x in pkt)
+        )
         return self.parse(pkt)
 
     def receive_blocking(self, data=None):
@@ -810,9 +814,10 @@ class DummyTransport(RFXtrxTransport):
         """ Emulate a send by doing nothing (except printing debug info if
             requested) """
         pkt = bytearray(data)
-        if self.debug:
-            print("RFXTRX: Send: " +
-                  " ".join("0x{0:02x}".format(x) for x in pkt))
+        _LOGGER.debug(
+            "Send: " +
+            " ".join("0x{0:02x}".format(x) for x in pkt)
+        )
 
     def close(self):
         """Close."""
@@ -822,9 +827,8 @@ class DummyTransport(RFXtrxTransport):
 class DummyTransport2(PySerialTransport):
     """ Dummy transport for testing purposes """
     #  pylint: disable=super-init-not-called
-    def __init__(self, device="", debug=True):
+    def __init__(self, device=""):
         self.serial = _dummySerial(device, 38400, timeout=0.1)
-        self.debug = debug
         self._run_event = threading.Event()
         self._run_event.set()
 
@@ -834,17 +838,16 @@ class Connect:
     Has methods for sensors.
     """
     #  pylint: disable=too-many-instance-attributes, too-many-arguments
-    def __init__(self, device, event_callback=None, debug=False,
+    def __init__(self, device, event_callback=None,
                  transport_protocol=PySerialTransport,
                  modes=None):
         self._run_event = threading.Event()
         self._sensors = {}
         self._status = None
         self._modes = modes
-        self._debug = debug
         self.event_callback = event_callback
 
-        self.transport = transport_protocol(device, debug)
+        self.transport = transport_protocol(device)
         self._thread = threading.Thread(target=self._connect)
         self._thread.setDaemon(True)
         self._thread.start()
@@ -859,8 +862,10 @@ class Connect:
             self.set_recmodes(self._modes)
             self._status = self.send_get_status()
 
-        if self._debug:
-            print("RFXTRX: ", self._status.device)
+        if self._status:
+            _LOGGER.debug(
+                "Status: %s", self._status.device
+            )
 
         self.send_start()
 

--- a/doctest/test_lighting.txt
+++ b/doctest/test_lighting.txt
@@ -1,5 +1,9 @@
 Lighting tests
 ==============
+>>> import logging
+>>> import sys
+>>> logging.root.handlers #= []
+>>> logging.basicConfig(level=logging.DEBUG, format="RFXTRX: %(message)s", handlers=[logging.StreamHandler(sys.stdout)])
 
 
 Lighting1

--- a/doctest/test_lighting.txt
+++ b/doctest/test_lighting.txt
@@ -2,7 +2,7 @@ Lighting tests
 ==============
 >>> import logging
 >>> import sys
->>> logging.root.handlers #= []
+>>> logging.root.handlers = []
 >>> logging.basicConfig(level=logging.DEBUG, format="RFXTRX: %(message)s", handlers=[logging.StreamHandler(sys.stdout)])
 
 

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -19,6 +19,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import logging
 sys.path.append("../")
 
 import RFXtrx
@@ -28,6 +29,8 @@ def print_callback(event):
     print(event)
 
 def main():
+    logging.basicConfig(level=logging.DEBUG)
+
     if len(sys.argv) >= 2:
         rfxcom_device = sys.argv[1]
     else:
@@ -35,7 +38,7 @@ def main():
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
-    core = RFXtrx.Core(rfxcom_device, print_callback, debug=True, modes=modes_list)
+    core = RFXtrx.Core(rfxcom_device, print_callback, modes=modes_list)
 
     print (core)
     while True:

--- a/examples/send.py
+++ b/examples/send.py
@@ -26,7 +26,7 @@ from RFXtrx.pyserial import PySerialTransport
 from RFXtrx import LightingDevice
 from time import sleep
 
-transport = PySerialTransport('/dev/cu.usbserial-05VN8GHS', debug=True)
+transport = PySerialTransport('/dev/cu.usbserial-05VN8GHS')
 transport.reset()
 
 while True:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,7 +18,7 @@ class CoreTestCase(TestCase):
 
     def test_constructor(self):
         global num_calbacks
-        core = RFXtrx.Core(self.path, event_callback=_callback, debug=False,transport_protocol=RFXtrx.DummyTransport2)
+        core = RFXtrx.Core(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport2)
         while num_calbacks < 6:
             time.sleep(0.1)
 
@@ -29,7 +29,7 @@ class CoreTestCase(TestCase):
 
     def test_format_packet(self):
         # Lighting1
-        core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event = core.transport.parse(bytes_array)
         self.assertEquals(RFXtrx.ControlEvent, type(event))
@@ -304,7 +304,7 @@ class CoreTestCase(TestCase):
         self.assertFalse(temphum==energy)
 
     def test_equal_device_check(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
         data1 = bytearray(b'\x11\x5A\x01\x00\x2E\xB2\x03\x00\x00'
                           b'\x02\xB4\x00\x00\x0C\x46\xA8\x11\x69')
         energy = core.transport.receive(data1)
@@ -337,7 +337,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_get_device(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event = core.transport.parse(bytes_array)
@@ -383,7 +383,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_set_recmodes(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, 
+        core = RFXtrx.Connect(self.path, event_callback=_callback, 
                               transport_protocol=RFXtrx.DummyTransport)
         time.sleep(0.2)
         self.assertEquals(None, core._modes)
@@ -405,7 +405,7 @@ class CoreTestCase(TestCase):
           core.set_recmodes(['arc', 'oregon', 'unknown-mode'])
 
     def test_receive(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, debug=False, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
         time.sleep(0.2)
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])


### PR DESCRIPTION
This allow us to drop the debug config in home assistant.