### PR TITLE
Add support for tilt commands on RFY Venetian blinds

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -151,6 +151,58 @@ class RfyDevice(RFXtrxDevice):
         self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
         transport.send(pkt.data)
 
+    def send_up05sec(self, transport):
+        """ Send an 'Up05sec' command (UP or TILT UP depending on blind motor settings) using the given transport """
+        pkt = lowlevel.Rfy()
+        pkt.set_transmit(
+            self.subtype,
+            self.cmndseqnbr,
+            self.id_combined,
+            self.unitcode,
+            0x0F
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
+    def send_down05sec(self, transport):
+        """ Send a 'Down05sec' command (DOWN or TILT DOWN depending on blind motor settings) using the given transport """
+        pkt = lowlevel.Rfy()
+        pkt.set_transmit(
+            self.subtype,
+            self.cmndseqnbr,
+            self.id_combined,
+            self.unitcode,
+            0x10
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
+    def send_up2sec(self, transport):
+        """ Send an 'Up2sec' command (UP or TILT UP depending on blind motor settings) using the given transport """
+        pkt = lowlevel.Rfy()
+        pkt.set_transmit(
+            self.subtype,
+            self.cmndseqnbr,
+            self.id_combined,
+            self.unitcode,
+            0x11
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
+    def send_down2sec(self, transport):
+        """ Send a 'Down2sec' command (DOWN or TILT DOWN depending on blind motor settings) using the given transport """
+        pkt = lowlevel.Rfy()
+        pkt.set_transmit(
+            self.subtype,
+            self.cmndseqnbr,
+            self.id_combined,
+            self.unitcode,
+            0x12
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
     def send_stop(self, transport):
         """ Send a 'Stop' command using the given transport """
         pkt = lowlevel.Rfy()

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2349,6 +2349,10 @@ class Rfy(Packet):
     COMMANDS = {0x00: 'Stop',
                 0x01: 'Up',
                 0x03: 'Down',
+                0x0F: 'Up05sec',
+                0x10: 'Down05sec',
+                0x11: 'Up2sec',
+                0x12: 'Down2sec',
                 0x13: 'Enable sun automation',
                 0x14: 'Disable sun automation'}
     """


### PR DESCRIPTION
Adding up/down transmit <0.5 seconds and up/down transmit >2 seconds comands for Somfy Venetian blinds to add support for the following:

"Somfy Tilt motors can be configured in 2 modes – US or European.

To toggle between modes, press the Reset/Prg button 2.  Repeat until the LED, according to the desired configuration, lights up.  Store by pressing 2 s.

To control Venetian blinds in US mode: 
-	up/down (transmit <0.5 seconds): open or close
-	up/down (transmit >2 seconds) change angle
To control Venetian blinds in US mode: 
-	up/down (transmit <0.5 seconds): change angle  
-	up/down (transmit >2 seconds): open or close"

Copyright RFXCOM, source http://www.rfxcom.com/WebRoot/StoreNL2/Shops/78165469/MediaGallery/Downloads/RFXtrx_User_Guide.pdf


The new commands are added on top of the existing Up/Down commands and do not interfere with them, so this is backwards compatible.

Note this only adds support for the commands.  To actually use them in HA, changes in the HA rfxtrx component are needed.  I have made those and have been running them as a custom rfxtrx component for a few months.  Will submit them shortly.
