### PR TITLE
Add commands for Rfy venetian blinds tilt control

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -149,6 +149,22 @@ class RfyDevice(RFXtrxDevice):
         """ Send an 'Disable Sun Automation' command """
         self.send_command(transport, 0x14)
 
+    def send_up05sec(self, transport):
+        """ Send a '0.5 Seconds Up' command """
+        self.send_command(transport, 0x0F)
+
+    def send_down05sec(self, transport):
+        """ Send a '0.5 Seconds Down' command """
+        self.send_command(transport, 0x10)
+
+    def send_up2sec(self, transport):
+        """ Send a '2 Seconds Up' command """
+        self.send_command(transport, 0x11)
+
+    def send_down2sec(self, transport):
+        """ Send a '2 Seconds Down' command """
+        self.send_command(transport, 0x12)
+
 
 class LightingDevice(RFXtrxDevice):
     """ Concrete class for a control device """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -222,6 +222,10 @@ class CoreTestCase(TestCase):
         event.device.send_open(core.transport)
         event.device.send_close(core.transport)
         event.device.send_stop(core.transport)
+        event.device.send_up05sec(core.transport)
+        event.device.send_down05sec(core.transport)
+        event.device.send_up2sec(core.transport)
+        event.device.send_down2sec(core.transport)
 
         #temphumid
         bytes_array = [0x0a, 0x52, 0x01, 0x2a, 0x96, 0x03, 0x81, 0x41, 0x60, 0x03, 0x79]


### PR DESCRIPTION
Add up/down 0.5/2 sec commands needed to control tilt of Rfy venetian blinds.  The rest of the implementation will be added in the HA RFXtrx component.