### PR TITLE
Ignore packets with invalid length

### DIFF
--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2747,5 +2747,10 @@ def parse(data):
     if pkt is None:
         return None
 
-    pkt.load_receive(data)
+    try:
+        pkt.load_receive(data)
+    except IndexError:
+        # parsing failed due to invalid packet length
+        return None
+
     return pkt

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,6 +28,12 @@ class CoreTestCase(TestCase):
         core.close_connection()
         self.assertFalse(core._thread.is_alive())
 
+    def test_invalid_packet(self):
+        bytes_array = bytearray([0x09, 0x11, 0xd7, 0x00, 0x01, 0x1d, 0x14, 0x02, 0x79, 0x0a])
+        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        event = core.transport.parse(bytes_array)
+        self.assertIsNone(event)
+
     def test_format_packet(self):
         # Lighting1
         core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)


### PR DESCRIPTION
Ever since switching my Home Assistant setup to use RFXtrx over the network using ser2net the integration completely stopped receiving data from the RFXtrx devices every 3-4 days. Debug logs would look like this:

```
2021-05-08 17:00:54 DEBUG (Thread-4) [RFXtrx] Recv: 0x0a 0x52 0x09 0x0f 0xa7 0x00 0x00 0x94 0x36 0x01 0x79
2021-05-08 17:00:59 DEBUG (Thread-4) [RFXtrx] Recv: 0x08 0x50 0x07 0x10 0xa8 0x00 0x81 0x08 0x79 0x0a 0x52
2021-05-08 17:01:01 DEBUG (Thread-4) [RFXtrx] Recv: 0x09 0x11 0xd7 0x00 0x01 0x1d 0x14 0x02 0x79 0x0a
2021-05-08 17:01:01 ERROR (Thread-4) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/site-packages/RFXtrx/__init__.py", line 868, in _connect
    event = self.transport.receive_blocking()
  File "/usr/local/lib/python3.8/site-packages/RFXtrx/__init__.py", line 755, in receive_blocking
    return self.parse(pkt)
  File "/usr/local/lib/python3.8/site-packages/RFXtrx/__init__.py", line 612, in parse
    pkt = lowlevel.parse(data)
  File "/usr/local/lib/python3.8/site-packages/RFXtrx/lowlevel.py", line 2693, in parse
    pkt.load_receive(data)
  File "/usr/local/lib/python3.8/site-packages/RFXtrx/lowlevel.py", line 435, in load_receive
    self.level = data[10]
IndexError: bytearray index out of range
```
It seems that once in a while, an incomplete packet is received on the ser2net socket that still passes the validation in the pyRFXtrx library as the initial byte (packet length) happens to match the length of the received data. But the contents of the packet is too short causing the parsing to fail. Unfortunately this uncaught exception crashes the HA integration completely and the only way to recover is to restart HA. :-(

This PR provides a simple fix for the problem by just ignoring packages where parsing fails due to incorrect length. I've been running my local instance with this fix without problems for 2+ weeks now.