### PR TITLE
Fix bug in sock.recv

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -770,8 +770,8 @@ class PyNetworkTransport(RFXtrxTransport):
             if not data or data == '\x00':
                 continue
             pkt = bytearray(data)
-            while len(pkt) < pkt[0]:
-                data = self.sock.recv(pkt[0])
+            while len(pkt) < pkt[0]+1:
+                data = self.sock.recv(pkt[0]+1 - len(pkt))
                 pkt.extend(bytearray(data))
             _LOGGER.debug(
                 "Recv: %s",


### PR DESCRIPTION
If the packet is not fully read from the socket in one go, the second time it will read another set of bytes with the full length of the packet. This causes it to read part of the next packet.

Fixed by reading only the missing number of bytes.
Fixes #128 .