### PR TITLE
Cleanup tests and linting

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -568,7 +568,7 @@ class StatusEvent(RFXtrxEvent):
             type(self), self.device)
 
 ###############################################################################
-# DummySerila class
+# DummySerial class
 ###############################################################################
 
 
@@ -867,7 +867,7 @@ class Connect:
 
         self.transport = transport_protocol(device)
         self._thread = threading.Thread(target=self._connect)
-        self._thread.setDaemon(True)
+        self._thread.daemon = True
         self._thread.start()
         self._run_event.wait()
 

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -204,9 +204,9 @@ def get_recmode_tuple(mode_name):
     Return a tuple (listno, sublistno), or (None, None) if
     not found.
     """
-    for i in range(0, len(Status.RECMODES)):
-        if mode_name in Status.RECMODES[i]:
-            return (i, Status.RECMODES[i].index(mode_name))
+    for i, modes in enumerate(Status.RECMODES):
+        if mode_name in modes:
+            return (i, modes.index(mode_name))
     return (None, None)
 
 
@@ -287,8 +287,8 @@ class Lighting1(Packet):
             self.packettype = 0x10
             self.subtype = subtype
             hcode = id_string[0:1]
-            for hcode_num in self.HOUSECODES:
-                if self.HOUSECODES[hcode_num] == hcode:
+            for hcode_num, hcode_code in self.HOUSECODES.items():
+                if hcode_code == hcode:
                     self.housecode = hcode_num
             self.unitcode = int(id_string[1:])
             self._set_strings()
@@ -2582,8 +2582,7 @@ class RollerTrol(Packet):
              0x04: 'BlindsT4 / Raex YR1326',
              0x05: 'BlindsT5 / Media Mount',
              0x06: 'BlindsT6 / DC106/Rohrmotor24-RMF/Yooda',
-             0x07: 'BlindsT7 / Forest'
-    }
+             0x07: 'BlindsT7 / Forest'}
     """
     Mapping of numeric subtype values to strings, used in type_string
     """

--- a/pylintrc
+++ b/pylintrc
@@ -10,4 +10,17 @@ disable=
   redefined-variable-type
 
 
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once).
+disable=C0209
+
 [EXCEPTIONS]

--- a/tests/test_rollertrol.py
+++ b/tests/test_rollertrol.py
@@ -42,5 +42,9 @@ class RollerTrolTestCase(TestCase):
 
         rollertrol = RFXtrx.lowlevel.parse(bytearray(b'\x09\x19\x02\x00\x00\x9b\xa8\x01\x05\x00'))
         self.assertEqual(rollertrol.cmnd_string, "Unknown command (0x05)")
-        self.assertEqual(rollertrol.type_string, "Unknown type (0x19/0x02)")
+        self.assertEqual(rollertrol.type_string, "BlindsT2 / A-OK RF01")
+
+        rollertrol = RFXtrx.lowlevel.parse(bytearray(b'\x09\x19\xff\x00\x00\x9b\xa8\x01\x05\x00'))
+        self.assertEqual(rollertrol.cmnd_string, "Unknown command (0x05)")
+        self.assertEqual(rollertrol.type_string, "Unknown type (0x19/0xff)")
         

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, lint
+envlist = py37, py38, py39, py310, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Update tox to supported python3 versions, fix an outdated test, and sort
out a couple of linting recommendations. Ignore the lint advice for
formatting using f strings, as this project does not use f strings.