### PR TITLE
Add parsing for undecoded messages

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -438,6 +438,8 @@ class SensorEvent(RFXtrxEvent):
 
         self.values = {}
         self.pkt = pkt
+        if isinstance(pkt, lowlevel.Undecoded):
+            self.values['Payload'] = pkt.payload
         if isinstance(pkt, lowlevel.RfxMeter):
             self.values['Counter value'] = pkt.value
         if isinstance(pkt, (lowlevel.Temp, lowlevel.TempHumid,
@@ -510,9 +512,10 @@ class SensorEvent(RFXtrxEvent):
                 self.values['Sensor Status'] = pkt.teleinfo_ok
         if isinstance(pkt, lowlevel.Security1):
             self.values['Sensor Status'] = pkt.security1_status_string
-        if not isinstance(pkt, (lowlevel.Energy5, lowlevel.RfxMeter)):
+        if not isinstance(pkt, (lowlevel.Energy5, lowlevel.RfxMeter, lowlevel.Undecoded)):
             self.values['Battery numeric'] = pkt.battery
-        self.values['Rssi numeric'] = pkt.rssi
+        if not isinstance(pkt, lowlevel.Undecoded):
+            self.values["Rssi numeric"] = pkt.rssi
 
     def __str__(self):
         return "{0} device=[{1}] values={2}".format(
@@ -598,6 +601,8 @@ class _dummySerial:
                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00]  # sensor1
         self._data[7] = [0x0a, 0x20, 0x00, 0x00, 0x00,
                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00]  # sensor2
+        self._data[8] = [0x09, 0x03, 0x01, 0x1e,
+                         0x28, 0x0a, 0xb7, 0x66, 0x04, 0x74] # undecoded
         self._close_event = threading.Event()
 
     def write(self, *args, **kwargs):

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -1055,6 +1055,78 @@ class SensorPacket(Packet):
 
 
 ###############################################################################
+# Undecoded class
+###############################################################################
+
+class Undecoded(SensorPacket):
+    """
+    Data class for the Undecoded packet type
+    """
+
+    TYPES = {
+        0x00: 'ac',
+        0x01: 'arc',
+        0x02: 'ati',
+        0x03: 'hideki/upm',
+        0x04: 'lacrosse/viking',
+        0x05: 'ad',
+        0x06: 'mertik',
+        0x07: 'oregon1',
+        0x08: 'oregon2',
+        0x09: 'oregon3',
+        0x0A: 'proguard',
+        0x0B: 'visonic',
+        0x0C: 'nec',
+        0x0D: 'fs20',
+        0x0E: 'reserved',
+        0x0F: 'blinds',
+        0x10: 'rubicson',
+        0x11: 'ae',
+        0x12: 'fineoffset',
+        0x13: 'rgb',
+        0x14: 'rts',
+        0x15: 'selectplus',
+        0x16: 'homeconfort',
+        0x17: 'edisio',
+        0x18: 'honeywell',
+        0x19: 'funkbus',
+        0x1A: 'byronsx',
+    }
+    """
+    Mapping of numeric subtype values to strings, used in type_string
+    """
+
+    def __str__(self):
+        return ("Undecoded [subtype={0} payload={1}]").format(self.type_string,
+                                       self.payload)
+
+    def __init__(self):
+        """Constructor"""
+        super().__init__()
+        self.payload = None
+
+    def load_receive(self, data):
+        """Load data from a bytearray"""
+        self.data = data
+        self.packetlength = data[0]
+        self.packettype = data[1]
+
+        self.subtype = data[2]
+        self.payload = data[4:]
+
+        self._set_strings()
+
+    def _set_strings(self):
+        """Translate loaded numeric values into convenience strings"""
+        self.id_string = 'Undecoded'
+        if self.subtype in self.TYPES:
+            self.type_string = self.TYPES[self.subtype]
+        else:
+            # Degrade nicely for yet unknown subtypes
+            self.type_string = 'Unknown'
+
+
+###############################################################################
 # Temp class
 ###############################################################################
 
@@ -2695,6 +2767,7 @@ class RollerTrol(Packet):
 
 PACKET_TYPES = {
     0x01: Status,
+    0x03: Undecoded,
     0x10: Lighting1,
     0x11: Lighting2,
     0x12: Lighting3,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -20,10 +20,10 @@ class CoreTestCase(TestCase):
     def test_constructor(self):
         global num_calbacks
         core = RFXtrx.Core(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport2)
-        while num_calbacks < 6:
+        while num_calbacks < 7:
             time.sleep(0.1)
 
-        self.assertEqual(len(core.sensors()),2)
+        self.assertEqual(len(core.sensors()),3)
         self.assertTrue(core._thread.is_alive())
         core.close_connection()
         self.assertFalse(core._thread.is_alive())
@@ -179,7 +179,7 @@ class CoreTestCase(TestCase):
         event = core.transport.parse(bytes_array)
         self.assertEqual(RFXtrx.SensorEvent, type(event))
         self.assertEqual(event.__str__(),"<class 'RFXtrx.SensorEvent'> device=[<class 'RFXtrx.RFXtrxDevice'> type='BBQ1 - Maverick ET-732' id='fcd800:78'] values=[('Battery numeric', 9), ('Rssi numeric', 7), ('Temperature', 19), ('Temperature2', 19)]")
-        
+
         #baro
         bytes_array = [0x09, 0x53, 0x01, 0x2a, 0x96, 0x03, 0x04, 0x06, 0x00, 0x79]
         event = core.transport.parse(bytes_array)
@@ -209,7 +209,7 @@ class CoreTestCase(TestCase):
         event = core.transport.parse(bytes_array)
         self.assertEqual(RFXtrx.SensorEvent, type(event))
         self.assertEqual(event.__str__(),"<class 'RFXtrx.SensorEvent'> device=[<class 'RFXtrx.RFXtrxDevice'> type='CARTELECTRONIC_ENCODER' id='3ffe61a3'] values=[('Battery numeric', 9), ('Count', 0), ('Counter value', 18388), ('Rssi numeric', 6)]")
-       
+
         #Cartelectronic Linky
         bytes_array = [0x15, 0x60, 0x03, 0x5c, 0x2a, 0x29, 0xf2, 0x75, 0x00, 0x19, 0x8d, 0x3a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x02, 0xb9, 0x00, 0x69]
         event = core.transport.parse(bytes_array)
@@ -305,7 +305,7 @@ class CoreTestCase(TestCase):
         event = core.transport.parse(bytes_array)
         self.assertEqual(RFXtrx.SensorEvent, type(event))
         self.assertEqual(event.__str__(),"<class 'RFXtrx.SensorEvent'> device=[<class 'RFXtrx.RFXtrxDevice'> type='TR1 - WS1200' id='ee:09'] values=[('Battery numeric', 9), ('Rain total', 0.3), ('Rssi numeric', 6), ('Temperature', 10.1)]")
-       
+
 
         core.close_connection()
 
@@ -409,7 +409,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_set_recmodes(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, 
+        core = RFXtrx.Connect(self.path, event_callback=_callback,
                               transport_protocol=RFXtrx.DummyTransport)
         time.sleep(0.2)
         self.assertEqual(None, core._modes)

--- a/tests/test_undecoded.py
+++ b/tests/test_undecoded.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+import RFXtrx
+
+
+class UndecodedTestCase(TestCase):
+
+    def setUp(self):
+        self.parser = RFXtrx.lowlevel.Undecoded()
+
+    def test_parse_bytes(self):
+        self.data = bytearray([0x09, 0x03, 0x01, 0x04, 0x28, 0x0a, 0xb7, 0x66, 0x04, 0x70])
+        undecoded = RFXtrx.lowlevel.parse(self.data)
+        self.assertEqual(RFXtrx.lowlevel.Undecoded, type(undecoded))
+        self.assertEqual(undecoded.subtype, 0x01)
+        self.assertEqual(undecoded.type_string, 'arc')
+        self.assertEqual(undecoded.payload, bytearray([0x28, 0x0a, 0xb7, 0x66, 0x04, 0x70]))
+        self.assertEqual(undecoded.id_string,'Undecoded')


### PR DESCRIPTION
Hardcode the id_string to undecoded as there is no way to differentiate
undecoded messages from each other. It will be up to the consumer to
parse the payload.