### PR TITLE
Switch to full length rfy commands

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -246,10 +246,10 @@ class CoreTestCase(TestCase):
         event.device.send_stop(core.transport)
 
         #Rfy
-        bytes_array = bytearray(b'\x08\x1A\x00\x00\x0A\x00\x01\x01\x03')
+        bytes_array = bytearray(b'\x0C\x1A\x00\x00\x0A\x00\x01\x01\x03\x00\x00\x00\x03')
         event= core.transport.receive(bytes_array)
         self.assertEqual(RFXtrx.ControlEvent, type(event))
-        self.assertEqual(event.__str__(),"<class 'RFXtrx.ControlEvent'> device=[<class 'RFXtrx.RfyDevice'> type='Rfy' id='0a0001:1'] values=[('Command', 'Down')]")
+        self.assertEqual(event.__str__(),"<class 'RFXtrx.ControlEvent'> device=[<class 'RFXtrx.RfyDevice'> type='Rfy' id='0a0001:1'] values=[('Command', 'Down'), ('Rssi numeric', 0)]")
         event.device.send_open(core.transport)
         event.device.send_close(core.transport)
         event.device.send_stop(core.transport)

--- a/tests/test_rfy.py
+++ b/tests/test_rfy.py
@@ -6,9 +6,9 @@ import RFXtrx
 class RfyTestCase(TestCase):
     def test_parse_bytes(self):
 
-        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x08\x1A\x00\x00\x0A\x00\x01\x01\x03'))
-        self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=Down]")
-        self.assertEqual(rfy.packetlength, 8)
+        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x0C\x1A\x00\x00\x0A\x00\x01\x01\x03\x00\x00\x00\x30'))
+        self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=Down, rssi=3]")
+        self.assertEqual(rfy.packetlength, 12)
         self.assertEqual(rfy.subtype, 0)
         self.assertEqual(rfy.type_string, "Rfy")
         self.assertEqual(rfy.seqnbr, 0)
@@ -18,8 +18,8 @@ class RfyTestCase(TestCase):
 
         rfy = RFXtrx.lowlevel.Rfy()
         rfy.set_transmit(0, 0, 0x0a0001, 1, 3)
-        self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=Down]")
-        self.assertEqual(rfy.packetlength, 8)
+        self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=Down, rssi=0]")
+        self.assertEqual(rfy.packetlength, 12)
         self.assertEqual(rfy.subtype, 0)
         self.assertEqual(rfy.type_string, "Rfy")
         self.assertEqual(rfy.seqnbr, 0)
@@ -36,11 +36,11 @@ class RfyTestCase(TestCase):
         self.assertEqual(rfy.__str__(), "<class 'RFXtrx.RfyDevice'> type='Rfy' id='0a0001:1'")
         self.assertEqual(rfy.unitcode, 1)
 
-        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x08\x1A\x01\x00\x0A\x00\x01\x01\x05'))
+        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x0C\x1A\x01\x00\x0A\x00\x01\x01\x05\x00\x00\x00\x30'))
         self.assertEqual(rfy.cmnd_string, "Unknown command (0x05)")
         self.assertEqual(rfy.type_string, "Rfy Extended")
 
-        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x08\x1A\x02\x00\x0A\x00\x01\x01\x05'))
+        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x0C\x1A\x02\x00\x0A\x00\x01\x01\x05\x00\x00\x00\x30'))
         self.assertEqual(rfy.cmnd_string, "Unknown command (0x05)")
         self.assertEqual(rfy.type_string, "Unknown type (0x1a/0x02)")
         


### PR DESCRIPTION
The current SDK from RFX used 0x0c long RFY commands. It might be these where 0x0x long at some point in the past, but they are not now. Adjust to use the new longer commands wich also contain RSSI.