### PR TITLE
Fix invalid RSSI byte used for TIC parsing.

### DIFF
--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2264,7 +2264,7 @@ class Cartelectronic(SensorPacket):
                 self.currentwatt = None
             self.state_byte = data[20]
             self.teleinfo_ok = not (data[20] & 0x04) == 0x04
-            self.rssi_byte = data[17]
+            self.rssi_byte = data[21]
         elif self.subtype == 0x02:
             # Cartelectronic Encoder
             self.counter1 = ((data[8] * pow(2, 24)) + (data[9] << 16) +

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -215,7 +215,7 @@ class CoreTestCase(TestCase):
                        0x79]
         event = core.transport.parse(bytes_array)
         self.assertEqual(RFXtrx.SensorEvent, type(event))
-        self.assertEqual(event.__str__(),"<class 'RFXtrx.SensorEvent'> device=[<class 'RFXtrx.RFXtrxDevice'> type='CARTELECTRONIC_TIC' id='77d200686'] values=[('Battery numeric', 0), ('Contract type', 17), ('Count', 0), ('Counter value', 3838665), ('Energy usage', 330), ('Rssi numeric', 0), ('Sensor Status', True)]")
+        self.assertEqual(event.__str__(),"<class 'RFXtrx.SensorEvent'> device=[<class 'RFXtrx.RFXtrxDevice'> type='CARTELECTRONIC_TIC' id='77d200686'] values=[('Battery numeric', 9), ('Contract type', 17), ('Count', 0), ('Counter value', 3838665), ('Energy usage', 330), ('Rssi numeric', 7), ('Sensor Status', True)]")
 
         #Cartelectronic Encoder
         bytes_array = [0x11, 0x60, 0x02, 0x5f, 0x3f, 0xfe, 0x61, 0xa3, 0x00, 0x00, 0x47, 0xd4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x69]


### PR DESCRIPTION
This fixes the random RSSI/Battery information reported here:
https://github.com/home-assistant/core/issues/67823#issuecomment-1106810937