### PR TITLE
Support historic Rfy packet lenghts

### DIFF
--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2618,15 +2618,21 @@ class Rfy(Packet):
         self.id1 = data[4]
         self.id2 = data[5]
         self.id3 = data[6]
-        self.unitcode = data[7]
-        self.cmnd = data[8]
-        self.rfu1 = data[9]
-        self.rfu2 = data[10]
-        self.rfu3 = data[11]
-        self.rssi_byte = data[12]
-        self.rssi = self.rssi_byte >> 4
-
         self.id_combined = (self.id1 << 16) + (self.id2 << 8) + self.id3
+        self.unitcode = data[7]
+
+        # Packet without command has been used in home assistant
+        if self.packetlength >= 8:
+            self.cmnd = data[8]
+
+        # Packet was extended in 9.17
+        if self.packetlength >= 12:
+            self.rfu1 = data[9]
+            self.rfu2 = data[10]
+            self.rfu3 = data[11]
+            self.rssi_byte = data[12]
+            self.rssi = self.rssi_byte >> 4
+
         self._set_strings()
 
     def set_transmit(self, subtype, seqnbr, id_combined, unitcode, cmnd):

--- a/tests/test_rfy.py
+++ b/tests/test_rfy.py
@@ -4,8 +4,28 @@ import RFXtrx
 
 
 class RfyTestCase(TestCase):
-    def test_parse_bytes(self):
+    def test_parse_bytes_legacy_format(self):
+        ### Tests with legacy formats used by home assistant.
+        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x08\x1A\x00\x00\x0A\x00\x01\x01\x03'))
+        self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=Down, rssi=None]")
+        self.assertEqual(rfy.packetlength, 8)
+        self.assertEqual(rfy.subtype, 0)
+        self.assertEqual(rfy.type_string, "Rfy")
+        self.assertEqual(rfy.seqnbr, 0)
+        self.assertEqual(rfy.id_string, "0a0001:1")
+        self.assertEqual(rfy.cmnd, 3)
+        self.assertEqual(rfy.cmnd_string, "Down")
 
+        rfy = RFXtrx.lowlevel.parse(bytearray(b'\x07\x1A\x00\x00\x0A\x00\x01\x01'))
+        self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=None, rssi=None]")
+        self.assertEqual(rfy.packetlength, 7)
+        self.assertEqual(rfy.subtype, 0)
+        self.assertEqual(rfy.type_string, "Rfy")
+        self.assertEqual(rfy.seqnbr, 0)
+        self.assertEqual(rfy.id_string, "0a0001:1")
+
+
+    def test_parse_bytes(self):
         rfy = RFXtrx.lowlevel.parse(bytearray(b'\x0C\x1A\x00\x00\x0A\x00\x01\x01\x03\x00\x00\x00\x30'))
         self.assertEqual(rfy.__repr__(), "Rfy [subtype=0, seqnbr=0, id=0a0001:1, cmnd=Down, rssi=3]")
         self.assertEqual(rfy.packetlength, 12)


### PR DESCRIPTION
Restore support for parsing legacy packet formats used in Home Assistant for Rfy packets.