### PR TITLE
Add support for Itho HRU400 heat recovery unit (868MHz)

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -444,6 +444,51 @@ class ChimeDevice(RFXtrxDevice):
         pkt.set_transmit(self.subtype, 0, self.id1, self.id2, sound)
         transport.send(pkt.data)
 
+
+class FanDevice(RFXtrxDevice):
+    """ Concrete class for a Fan control device """
+    def __init__(self, pkt):
+        super().__init__(pkt)
+        self.subtype = pkt.subtype
+        self.id_combined = pkt.id_combined
+        self.cmndseqnbr = 0
+
+    def send_low(self, transport):
+        """ Send a 'Low' command using the given transport """
+        self.send_command(transport, lowlevel.Fan.Commands.LOW.value)
+
+    def send_medium(self, transport):
+        """ Send a 'Medium' command using the given transport """
+        self.send_command(transport, lowlevel.Fan.Commands.MEDIUM.value)
+
+    def send_high(self, transport):
+        """ Send a 'High' command using the given transport """
+        self.send_command(transport, lowlevel.Fan.Commands.HIGH.value)
+
+    def send_timer15(self, transport):
+        """ Send a 'Timer 15 min' command using the given transport """
+        self.send_command(transport, lowlevel.Fan.Commands.TIMER15.value)
+
+    def send_timer30(self, transport):
+        """ Send a 'Timer 30 min' command using the given transport """
+        self.send_command(transport, lowlevel.Fan.Commands.TIMER30.value)
+
+    def send_timer60(self, transport):
+        """ Send a 'Timer 60 min' command using the given transport """
+        self.send_command(transport, lowlevel.Fan.Commands.TIMER60.value)
+
+    def send_command(self, transport, command):
+        """ Send a command using the given transport """
+        pkt = lowlevel.Fan()
+        pkt.set_transmit(
+            self.subtype,
+            self.id_combined,
+            command
+        )
+        self.cmndseqnbr = (self.cmndseqnbr + 1) % 5
+        transport.send(pkt.data)
+
+
 ###############################################################################
 # get_device_from_pkt method
 ###############################################################################
@@ -466,6 +511,8 @@ def get_device_from_pkt(pkt):
         device = SecurityDevice(pkt)
     elif isinstance(pkt, lowlevel.Funkbus):
         device = FunkDevice(pkt)
+    elif isinstance(pkt, lowlevel.Fan):
+        device = FanDevice(pkt)
     else:
         device = RFXtrxDevice(pkt)
     return device

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -140,7 +140,13 @@ class Status(Packet):
         ],
         [
             "keeloq",
-            "homeconfort"
+            "homeconfort",
+            "undecoded",
+            "undecoded",
+            "itho hru400", # 868Mhz
+            "undecoded", # Orcon 868MHz
+            "undecoded", # Itho CVE, HRU ECO 868MHz
+            "undecoded"  # Itho_CVE RFT 868MHz
         ]
     ]
     """

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -3035,6 +3035,11 @@ class Fan(Packet):
                 0x09: 'Join',
                 0x0A: 'Leave'}
 
+    def __str__(self):
+        return ("Fan [subtype={0}, seqnbr={1}, id={2}, cmnd={3}]") \
+            .format(self.type_string, self.seqnbr, self.id_string,
+                    self.cmnd_string)
+
     def __init__(self):
         """Constructor"""
         super().__init__()

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+import RFXtrx
+
+
+class FanTestCase(TestCase):
+        
+    def test_parse_bytes(self):
+        data = [0x08, 0x17, 0x0D, 0x00, 0x12, 0x34, 0x56, 0x01, 0x00]
+        fan = RFXtrx.lowlevel.parse(data)
+        self.assertEqual(RFXtrx.lowlevel.Fan, type(fan))
+        self.assertEqual(fan.id1, 0x12)
+        self.assertEqual(fan.id2, 0x34)
+        self.assertEqual(fan.id3, 0x56)
+        self.assertEqual(fan.id_string,'123456')
+        self.assertEqual(fan.cmnd, 0x01)
+        self.assertEqual(fan.cmnd_string, 'Low')

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -15,3 +15,4 @@ class FanTestCase(TestCase):
         self.assertEqual(fan.id_string,'123456')
         self.assertEqual(fan.cmnd, 0x01)
         self.assertEqual(fan.cmnd_string, 'Low')
+        self.assertEqual(str(fan), 'Fan [subtype=Itho HRU400, seqnbr=0, id=123456, cmnd=Low]')

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,18 +1,35 @@
 from unittest import TestCase
 
 import RFXtrx
+from RFXtrx.lowlevel import Fan
 
-
-class FanTestCase(TestCase):
+class packetTestCase(TestCase):
         
     def test_parse_bytes(self):
         data = [0x08, 0x17, 0x0D, 0x00, 0x12, 0x34, 0x56, 0x01, 0x00]
-        fan = RFXtrx.lowlevel.parse(data)
-        self.assertEqual(RFXtrx.lowlevel.Fan, type(fan))
-        self.assertEqual(fan.id1, 0x12)
-        self.assertEqual(fan.id2, 0x34)
-        self.assertEqual(fan.id3, 0x56)
-        self.assertEqual(fan.id_string,'123456')
-        self.assertEqual(fan.cmnd, 0x01)
-        self.assertEqual(fan.cmnd_string, 'Low')
-        self.assertEqual(str(fan), 'Fan [subtype=Itho HRU400, seqnbr=0, id=123456, cmnd=Low]')
+        packet = RFXtrx.lowlevel.parse(data)
+
+        self.assertEqual(Fan, type(packet))
+        self.assertEqual(packet.id1, 0x12)
+        self.assertEqual(packet.id2, 0x34)
+        self.assertEqual(packet.id3, 0x56)
+        self.assertEqual(packet.id_string,'123456')
+        self.assertEqual(packet.cmnd, 0x01)
+        self.assertEqual(packet.cmnd_string, 'Low')
+        self.assertEqual(str(packet), 'Fan [subtype=Itho HRU400, seqnbr=0, id=123456, cmnd=Low]')
+
+
+    def test_set_transmit(self):
+        packet = RFXtrx.lowlevel.Fan()
+        packet.set_transmit(0x0D, 0x123456, Fan.Commands.MEDIUM.value)
+        print(packet)
+
+        self.assertEqual(packet.packetlength, 8)
+        self.assertEqual(packet.packettype, 0x17)
+        self.assertEqual(packet.subtype, 0x0D)
+        self.assertEqual(packet.id_combined, 0x123456)
+        self.assertEqual(packet.id1, 0x12)
+        self.assertEqual(packet.id2, 0x34)
+        self.assertEqual(packet.id3, 0x56)
+        self.assertEqual(packet.cmnd, 0x02)
+        self.assertEqual(packet.data, bytearray([0x08, 0x17, 0x0D, 0x00, 0x12, 0x34, 0x56, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))


### PR DESCRIPTION
The Itho HRU400 is a heat recovery devices that communicates on the 868MHz band.
Last week RFXCOM added support in the latest firmware for the RFX868 devices.

The remote sends commands with packet type 0x17 (used by more types of Itho devices) and the HRU400 uses subtype 0x0D.
The commands supported are Low (0x01), Medium (0x02), High (0x03) and three timer variations: 15 min (0x04), 30 min (0x05), 60 min (0x06). In addition there are commands to Join a new remote (0x09) and "Leave" (0x10), which I did not test.