### PR TITLE
Fix closing network transport

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -911,6 +911,7 @@ class PyNetworkTransport(RFXtrxTransport):
     def close(self):
         """ close connection to rfxtrx device """
         self._run_event.clear()
+        self.sock.shutdown(socket.SHUT_RDWR)
         self.sock.close()
 
 


### PR DESCRIPTION
Fixes #146.

The network transport is waiting on a blocking `socket.recv()` call. Even though the connection to the client is closed and the `_run_event` is cleared, this does not unblock the socket.
This is simply fixed by adding a call to `socket.shutdown(socket.SHUT_RDWR)` which _does_ unblock the waiting `recv` call.