### PR TITLE
Rework transport to leave re-connect to user

### DIFF
--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -28,6 +28,7 @@ import glob
 import socket
 import threading
 import logging
+from contextlib import suppress
 
 from time import sleep
 
@@ -884,7 +885,8 @@ class PySerialTransport(RFXtrxTransport):
     @transport_errors("close")
     def close(self):
         """ close connection to rfxtrx device """
-        self.serial.close()
+        with suppress(serial.SerialException):
+            self.serial.close()
 
 ###############################################################################
 # PyNetworkTransport class
@@ -957,11 +959,11 @@ class PyNetworkTransport(RFXtrxTransport):
             raise RFXtrxTransportError(
                 "Reset failed: {0}".format(exception)) from exception
 
-    @transport_errors("reset")
+    @transport_errors("close")
     def close(self):
         """ close connection to rfxtrx device """
-        self.sock.shutdown(socket.SHUT_RDWR)
-        self.sock.close()
+        with suppress(socket.error):
+            self.sock.close()
 
 
 class DummyTransport(RFXtrxTransport):

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -852,18 +852,26 @@ class PySerialTransport(RFXtrxTransport):
             "Send: %s",
             " ".join("0x{0:02x}".format(x) for x in pkt)
         )
-        self.serial.write(pkt)
+        try:
+            self.serial.write(pkt)
+        except serial.SerialException as exception:
+            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
 
     def reset(self):
         """ Reset the RFXtrx """
-        self.send(b'\x0D\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-        sleep(0.3)  # Should work with 0.05, but not for me
-        self.serial.flushInput()
+        try:
+            self.send(b'\x0D\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+            sleep(0.3)  # Should work with 0.05, but not for me
+            self.serial.flushInput()
+        except serial.SerialException as exception:
+            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
 
     def close(self):
         """ close connection to rfxtrx device """
-        self.serial.close()
-
+        try:
+            self.serial.close()
+        except serial.SerialException as exception:
+            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
 
 ###############################################################################
 # PyNetworkTransport class
@@ -925,18 +933,27 @@ class PyNetworkTransport(RFXtrxTransport):
             "Send: %s",
             " ".join("0x{0:02x}".format(x) for x in pkt)
         )
-        self.sock.send(pkt)
+        try:
+            self.sock.send(pkt)
+        except socket.error as exception:
+            raise RFXtrxTransportError("Send failed: {0}".format(exception)) from exception
 
     def reset(self):
         """ Reset the RFXtrx """
-        self.send(b'\x0D\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-        sleep(0.3)
-        self.sock.sendall(b'')
+        try:
+            self.send(b'\x0D\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+            sleep(0.3)
+            self.sock.sendall(b'')
+        except socket.error as exception:
+            raise RFXtrxTransportError("Reset failed: {0}".format(exception)) from exception
 
     def close(self):
         """ close connection to rfxtrx device """
-        self.sock.shutdown(socket.SHUT_RDWR)
-        self.sock.close()
+        try:
+            self.sock.shutdown(socket.SHUT_RDWR)
+            self.sock.close()
+        except socket.error as exception:
+            raise RFXtrxTransportError("Close failed: {0}".format(exception)) from exception
 
 
 class DummyTransport(RFXtrxTransport):

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -1027,8 +1027,8 @@ class Connect:
     Has methods for sensors.
     """
     #  pylint: disable=too-many-instance-attributes, too-many-arguments
-    def __init__(self, device, event_callback=None,
-                 transport_protocol=PySerialTransport,
+    def __init__(self, event_callback=None,
+                 transport=None,
                  modes=None):
         self._run_event = threading.Event()
         self._sensors = {}
@@ -1036,7 +1036,7 @@ class Connect:
         self._modes = modes
         self._thread = threading.Thread(target=self._connect, daemon=True)
         self.event_callback = event_callback
-        self.transport: RFXtrxTransport = transport_protocol(device)
+        self.transport: RFXtrxTransport = transport
 
     def connect(self, timeout=None):
         """Connect to device."""

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -1027,8 +1027,7 @@ class Connect:
     Has methods for sensors.
     """
     #  pylint: disable=too-many-instance-attributes, too-many-arguments
-    def __init__(self, event_callback=None,
-                 transport=None,
+    def __init__(self, transport, event_callback=None,
                  modes=None):
         self._run_event = threading.Event()
         self._sensors = {}

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -861,17 +861,18 @@ class PySerialTransport(RFXtrxTransport):
             self.serial.write(pkt)
         except serial.SerialException as exception:
             raise RFXtrxTransportError(
-                "Connection was lost: {0}".format(exception)) from exception
+                "Send failed: {0}".format(exception)) from exception
 
     def reset(self):
         """ Reset the RFXtrx """
         try:
-            self.send(b'\x0D\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+            self.send(b'\x0D\x00\x00\x00\x00\x00\x00'
+                      b'\x00\x00\x00\x00\x00\x00\x00')
             sleep(0.3)  # Should work with 0.05, but not for me
             self.serial.flushInput()
         except serial.SerialException as exception:
             raise RFXtrxTransportError(
-                "Connection was lost: {0}".format(exception)) from exception
+                "Reset failed: {0}".format(exception)) from exception
 
     def close(self):
         """ close connection to rfxtrx device """
@@ -879,7 +880,7 @@ class PySerialTransport(RFXtrxTransport):
             self.serial.close()
         except serial.SerialException as exception:
             raise RFXtrxTransportError(
-                "Connection was lost: {0}".format(exception)) from exception
+                "Close failed: {0}".format(exception)) from exception
 
 ###############################################################################
 # PyNetworkTransport class
@@ -901,7 +902,8 @@ class PyNetworkTransport(RFXtrxTransport):
             self.sock.settimeout(None)
             _LOGGER.debug("Connected to network socket")
         except socket.error as exception:
-            raise RFXtrxTransportError("Connection failed: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection failed: {0}".format(exception)) from exception
 
     def receive_blocking(self):
         """ Wait until a packet is received and return with an RFXtrxEvent """
@@ -951,7 +953,8 @@ class PyNetworkTransport(RFXtrxTransport):
     def reset(self):
         """ Reset the RFXtrx """
         try:
-            self.send(b'\x0D\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+            self.send(b'\x0D\x00\x00\x00\x00\x00\x00'
+                      b'\x00\x00\x00\x00\x00\x00\x00')
             sleep(0.3)
             self.sock.sendall(b'')
         except socket.error as exception:

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -748,12 +748,14 @@ class _dummySerial:
 # RFXtrxTransportError class
 ###############################################################################
 
+
 class RFXtrxTransportError(Exception):
     """ Connection error """
 
 ###############################################################################
 # RFXtrxTransport class
 ###############################################################################
+
 
 class RFXtrxTransport:
     """ Abstract superclass for all transport mechanisms """
@@ -818,13 +820,15 @@ class PySerialTransport(RFXtrxTransport):
                 _LOGGER.debug("Attempting connection by name %s", port)
                 self.serial = serial.Serial(port[0], 38400)
         except serial.SerialException as exception:
-            raise RFXtrxTransportError("Connection failed: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection failed: {0}".format(exception)) from exception
 
     def receive_blocking(self):
         try:
             return self._receive_packet()
         except serial.SerialException as exception:
-            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection was lost: {0}".format(exception)) from exception
 
     def _receive_packet(self):
         """ Wait until a packet is received and return with an RFXtrxEvent """
@@ -856,7 +860,8 @@ class PySerialTransport(RFXtrxTransport):
         try:
             self.serial.write(pkt)
         except serial.SerialException as exception:
-            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection was lost: {0}".format(exception)) from exception
 
     def reset(self):
         """ Reset the RFXtrx """
@@ -865,14 +870,16 @@ class PySerialTransport(RFXtrxTransport):
             sleep(0.3)  # Should work with 0.05, but not for me
             self.serial.flushInput()
         except serial.SerialException as exception:
-            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection was lost: {0}".format(exception)) from exception
 
     def close(self):
         """ close connection to rfxtrx device """
         try:
             self.serial.close()
         except serial.SerialException as exception:
-            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection was lost: {0}".format(exception)) from exception
 
 ###############################################################################
 # PyNetworkTransport class
@@ -901,7 +908,8 @@ class PyNetworkTransport(RFXtrxTransport):
         try:
             return self._receive_packet()
         except socket.error as exception:
-            raise RFXtrxTransportError("Connection was lost: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Connection was lost: {0}".format(exception)) from exception
 
     def _receive_packet(self):
         """ Wait until a packet is received and return with an RFXtrxEvent """
@@ -937,7 +945,8 @@ class PyNetworkTransport(RFXtrxTransport):
         try:
             self.sock.send(pkt)
         except socket.error as exception:
-            raise RFXtrxTransportError("Send failed: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Send failed: {0}".format(exception)) from exception
 
     def reset(self):
         """ Reset the RFXtrx """
@@ -946,7 +955,8 @@ class PyNetworkTransport(RFXtrxTransport):
             sleep(0.3)
             self.sock.sendall(b'')
         except socket.error as exception:
-            raise RFXtrxTransportError("Reset failed: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Reset failed: {0}".format(exception)) from exception
 
     def close(self):
         """ close connection to rfxtrx device """
@@ -954,7 +964,8 @@ class PyNetworkTransport(RFXtrxTransport):
             self.sock.shutdown(socket.SHUT_RDWR)
             self.sock.close()
         except socket.error as exception:
-            raise RFXtrxTransportError("Close failed: {0}".format(exception)) from exception
+            raise RFXtrxTransportError(
+                "Close failed: {0}".format(exception)) from exception
 
 
 class DummyTransport(RFXtrxTransport):

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -777,6 +777,9 @@ class RFXtrxTransport:
             return obj
         return None
 
+    def connect(self):
+        """ connect to device """
+
     def reset(self):
         """ reset the rfxtrx device """
 
@@ -801,7 +804,6 @@ class PySerialTransport(RFXtrxTransport):
     def __init__(self, port):
         self.port = port
         self.serial = None
-        self.connect()
 
     def connect(self):
         """ Open a serial connexion """
@@ -874,7 +876,6 @@ class PyNetworkTransport(RFXtrxTransport):
     def __init__(self, hostport):
         self.hostport = hostport    # must be a (host, port) tuple
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.connect()
 
     def connect(self):
         """ Open a socket connection """
@@ -943,6 +944,9 @@ class DummyTransport(RFXtrxTransport):
         self.device = device
         self._close_event = threading.Event()
 
+    def connect(self):
+        pass
+
     def receive(self, data=None):
         """ Emulate a receive by parsing the given data """
         if data is None:
@@ -979,6 +983,8 @@ class DummyTransport2(PySerialTransport):
     def __init__(self, device=""):
         self.serial = _dummySerial(device, 38400, timeout=0.1)
         self._run_event = threading.Event()
+
+    def connect(self):
         self._run_event.set()
 
 
@@ -995,10 +1001,11 @@ class Connect:
         self._status = None
         self._modes = modes
         self.event_callback = event_callback
-
         self.transport: RFXtrxTransport = transport_protocol(device)
-        self._thread = threading.Thread(target=self._connect)
-        self._thread.daemon = True
+
+    def connect(self):
+        self.transport.connect()
+        self._thread = threading.Thread(target=self._connect, daemon=True)
         self._thread.start()
         self._run_event.wait()
 

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -1011,6 +1011,7 @@ class Connect:
         self._thread.start()
         if not self._run_event.wait(timeout):
             self.close_connection()
+            raise TimeoutError()
 
     def _connect(self):
         try:

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -26,7 +26,6 @@ This module provides the base implementation for pyRFXtrx
 import glob
 import socket
 import threading
-import time
 import logging
 
 from time import sleep
@@ -680,8 +679,10 @@ class ConnectionEvent(RFXtrxEvent):
     def __init__(self):
         super().__init__(None)
 
+
 class ConnectionLost(ConnectionEvent):
     """ Connection lost """
+
 
 class ConnectionDone(ConnectionEvent):
     """ Connection lost """

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -1034,12 +1034,13 @@ class Connect:
         self._sensors = {}
         self._status = None
         self._modes = modes
+        self._thread = threading.Thread(target=self._connect, daemon=True)
         self.event_callback = event_callback
         self.transport: RFXtrxTransport = transport_protocol(device)
 
     def connect(self, timeout=None):
+        """Connect to device."""
         self.transport.connect(timeout)
-        self._thread = threading.Thread(target=self._connect, daemon=True)
         self._thread.start()
         if not self._run_event.wait(timeout):
             self.close_connection()
@@ -1052,6 +1053,7 @@ class Connect:
             _LOGGER.info("Connection lost %s", exception)
         except Exception:
             _LOGGER.exception("Unexpected exception from transport")
+            raise
         finally:
             if self.event_callback and self._run_event.is_set():
                 self.event_callback(ConnectionLost())

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -807,7 +807,8 @@ def transport_errors(message):
             except (socket.error,
                     serial.SerialException,
                     OSError) as exception:
-                _LOGGER.debug("%s failed: %s", message, str(exception), exc_info=True)
+                _LOGGER.debug("%s failed: %s", message,
+                              str(exception), exc_info=True)
                 raise RFXtrxTransportError(
                     "{0} failed: {1}".format(message, exception)
                 ) from exception

--- a/RFXtrx/__init__.py
+++ b/RFXtrx/__init__.py
@@ -1010,7 +1010,7 @@ class Connect:
         except Exception:
             _LOGGER.exception("Unexpected exception from transport")
         finally:
-            if self.event_callback:
+            if self.event_callback and self._run_event.is_set():
                 self.event_callback(ConnectionLost())
 
     def _connect_internal(self):

--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -2278,7 +2278,7 @@ class Cartelectronic(SensorPacket):
                                   (data[10] << 8) + data[11])
             self.prodwatthours = ((data[12] * pow(2, 24)) + (data[13] << 16) +
                                   (data[14] << 8) + data[15])
-            self.tarif_num = (data[16] & 0x0f)
+            self.tarif_num = data[16] & 0x0f
             self.voltage = data[17] + 200
             self.currentwatt = (data[18] << 8) + data[19]
             self.state_byte = data[20]
@@ -2378,7 +2378,7 @@ class Chime(Packet):
         self.id2 = id2
         self.sound = sound
         self.rssi = 0
-        self.rssi_byte = (self.rssi << 4)
+        self.rssi_byte = self.rssi << 4
         self.data = bytearray([self.packetlength, self.packettype,
                                self.subtype, self.seqnbr,
                                self.id1, self.id2, self.sound,

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -38,7 +38,7 @@ def main():
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
-    core = RFXtrx.Core(rfxcom_device, print_callback, modes=modes_list)
+    core = RFXtrx.Connect(print_callback, modes=modes_list, transport=RFXtrx.PySerialTransport(rfxcom_device))
     core.connect()
 
     print (core)

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -39,6 +39,7 @@ def main():
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
     core = RFXtrx.Core(rfxcom_device, print_callback, modes=modes_list)
+    core.connect()
 
     print (core)
     while True:

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -38,7 +38,7 @@ def main():
 
     modes_list = sys.argv[2].split() if len(sys.argv) > 2 else None
     print ("modes: ", modes_list)
-    core = RFXtrx.Connect(print_callback, modes=modes_list, transport=RFXtrx.PySerialTransport(rfxcom_device))
+    core = RFXtrx.Connect(RFXtrx.PySerialTransport(rfxcom_device), print_callback, modes=modes_list)
     core.connect()
 
     print (core)

--- a/examples/send.py
+++ b/examples/send.py
@@ -27,6 +27,7 @@ from RFXtrx import LightingDevice
 from time import sleep
 
 transport = PySerialTransport('/dev/cu.usbserial-05VN8GHS')
+transport.connect()
 transport.reset()
 
 while True:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -20,6 +20,7 @@ class CoreTestCase(TestCase):
     def test_constructor(self):
         global num_calbacks
         core = RFXtrx.Core(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport2)
+        core.connect()
         while num_calbacks < 7:
             time.sleep(0.1)
 
@@ -31,12 +32,14 @@ class CoreTestCase(TestCase):
     def test_invalid_packet(self):
         bytes_array = bytearray([0x09, 0x11, 0xd7, 0x00, 0x01, 0x1d, 0x14, 0x02, 0x79, 0x0a])
         core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core.connect()
         event = core.transport.parse(bytes_array)
         self.assertIsNone(event)
 
     def test_format_packet(self):
         # Lighting1
         core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core.connect()
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event = core.transport.parse(bytes_array)
         self.assertEqual(RFXtrx.ControlEvent, type(event))
@@ -359,6 +362,7 @@ class CoreTestCase(TestCase):
 
     def test_equal_device_check(self):
         core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core.connect()
         data1 = bytearray(b'\x11\x5A\x01\x00\x2E\xB2\x03\x00\x00'
                           b'\x02\xB4\x00\x00\x0C\x46\xA8\x11\x69')
         energy = core.transport.receive(data1)
@@ -392,6 +396,7 @@ class CoreTestCase(TestCase):
 
     def test_get_device(self):
         core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core.connect()
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event = core.transport.parse(bytes_array)
@@ -439,6 +444,7 @@ class CoreTestCase(TestCase):
     def test_set_recmodes(self):
         core = RFXtrx.Connect(self.path, event_callback=_callback,
                               transport_protocol=RFXtrx.DummyTransport)
+        core.connect()
         time.sleep(0.2)
         self.assertEqual(None, core._modes)
 
@@ -460,6 +466,7 @@ class CoreTestCase(TestCase):
 
     def test_receive(self):
         core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core.connect()
         time.sleep(0.2)
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,7 @@ class CoreTestCase(TestCase):
 
     def test_constructor(self):
         global num_calbacks
-        core = RFXtrx.Core(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport2)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport2(self.path))
         core.connect()
         while num_calbacks < 7:
             time.sleep(0.1)
@@ -31,14 +31,14 @@ class CoreTestCase(TestCase):
 
     def test_invalid_packet(self):
         bytes_array = bytearray([0x09, 0x11, 0xd7, 0x00, 0x01, 0x1d, 0x14, 0x02, 0x79, 0x0a])
-        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
         core.connect()
         event = core.transport.parse(bytes_array)
         self.assertIsNone(event)
 
     def test_format_packet(self):
         # Lighting1
-        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
         core.connect()
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event = core.transport.parse(bytes_array)
@@ -361,7 +361,7 @@ class CoreTestCase(TestCase):
         self.assertFalse(temphum==energy)
 
     def test_equal_device_check(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
         core.connect()
         data1 = bytearray(b'\x11\x5A\x01\x00\x2E\xB2\x03\x00\x00'
                           b'\x02\xB4\x00\x00\x0C\x46\xA8\x11\x69')
@@ -395,7 +395,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_get_device(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
         core.connect()
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
@@ -442,8 +442,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_set_recmodes(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback,
-                              transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
         core.connect()
         time.sleep(0.2)
         self.assertEqual(None, core._modes)
@@ -465,7 +464,7 @@ class CoreTestCase(TestCase):
           core.set_recmodes(['arc', 'oregon', 'unknown-mode'])
 
     def test_receive(self):
-        core = RFXtrx.Connect(self.path, event_callback=_callback, transport_protocol=RFXtrx.DummyTransport)
+        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
         core.connect()
         time.sleep(0.2)
         # Lighting1

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,7 @@ class CoreTestCase(TestCase):
 
     def test_constructor(self):
         global num_calbacks
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport2(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport2(self.path), event_callback=_callback)
         core.connect()
         while num_calbacks < 7:
             time.sleep(0.1)
@@ -31,14 +31,14 @@ class CoreTestCase(TestCase):
 
     def test_invalid_packet(self):
         bytes_array = bytearray([0x09, 0x11, 0xd7, 0x00, 0x01, 0x1d, 0x14, 0x02, 0x79, 0x0a])
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport(self.path), event_callback=_callback)
         core.connect()
         event = core.transport.parse(bytes_array)
         self.assertIsNone(event)
 
     def test_format_packet(self):
         # Lighting1
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport(self.path), event_callback=_callback)
         core.connect()
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
         event = core.transport.parse(bytes_array)
@@ -361,7 +361,7 @@ class CoreTestCase(TestCase):
         self.assertFalse(temphum==energy)
 
     def test_equal_device_check(self):
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport(self.path), event_callback=_callback)
         core.connect()
         data1 = bytearray(b'\x11\x5A\x01\x00\x2E\xB2\x03\x00\x00'
                           b'\x02\xB4\x00\x00\x0C\x46\xA8\x11\x69')
@@ -395,7 +395,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_get_device(self):
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport(self.path), event_callback=_callback)
         core.connect()
         # Lighting1
         bytes_array = bytearray([0x07, 0x10, 0x00, 0x2a, 0x45, 0x05, 0x01, 0x70])
@@ -442,7 +442,7 @@ class CoreTestCase(TestCase):
         core.close_connection()
 
     def test_set_recmodes(self):
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport(self.path), event_callback=_callback)
         core.connect()
         time.sleep(0.2)
         self.assertEqual(None, core._modes)
@@ -464,7 +464,7 @@ class CoreTestCase(TestCase):
           core.set_recmodes(['arc', 'oregon', 'unknown-mode'])
 
     def test_receive(self):
-        core = RFXtrx.Connect(event_callback=_callback, transport=RFXtrx.DummyTransport(self.path))
+        core = RFXtrx.Connect(RFXtrx.DummyTransport(self.path), event_callback=_callback)
         core.connect()
         time.sleep(0.2)
         # Lighting1

--- a/tests/test_transport_network.py
+++ b/tests/test_transport_network.py
@@ -7,9 +7,10 @@ import dataclasses
 import threading
 from typing import Tuple, List
 
+
 @pytest.fixture(name="server_socket")
 def fixture_server_socket():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('127.0.0.1', 0))
     sock.settimeout(1)
     sock.listen(1)
@@ -18,11 +19,13 @@ def fixture_server_socket():
     finally:
         sock.close()
 
+
 @dataclasses.dataclass
 class Server:
     address: Tuple
     connections: List[socket.socket]
     event = threading.Event()
+
 
 @pytest.fixture(name="server")
 def fixture_server(server_socket: socket.socket):
@@ -49,6 +52,7 @@ def fixture_server(server_socket: socket.socket):
             connection.close()
         thread.join()
 
+
 def connected_transport(server: Server):
     server.event.clear()
     transport = RFXtrx.PyNetworkTransport(server.address)
@@ -57,15 +61,18 @@ def connected_transport(server: Server):
     assert server.event.wait(10)
     return transport, server.connections[-1]
 
+
 def test_transport_shutdown_between_packet(server: Server):
     transport, connection = connected_transport(server)
-    connection.sendall(bytes([0x09, 0x03, 0x01, 0x04, 0x28, 0x0a, 0xb7, 0x66, 0x04, 0x70]))
+    connection.sendall(bytes([0x09, 0x03, 0x01, 0x04, 0x28,
+                              0x0a, 0xb7, 0x66, 0x04, 0x70]))
     connection.shutdown(socket.SHUT_RDWR)
 
     pkt = transport.receive_blocking()
     assert isinstance(pkt, RFXtrx.SensorEvent)
     with pytest.raises(RFXtrx.RFXtrxTransportError):
         transport.receive_blocking()
+
 
 def test_transport_shutdown_mid_packet(server: Server):
     transport, connection = connected_transport(server)
@@ -75,6 +82,7 @@ def test_transport_shutdown_mid_packet(server: Server):
     with pytest.raises(RFXtrx.RFXtrxTransportError):
         transport.receive_blocking()
 
+
 def test_transport_close_mid_packet(server: Server):
     transport, connection = connected_transport(server)
     connection.sendall(bytes([0x09, 0x03, 0x01, 0x04]))
@@ -82,6 +90,7 @@ def test_transport_close_mid_packet(server: Server):
 
     with pytest.raises(RFXtrx.RFXtrxTransportError):
         transport.receive_blocking()
+
 
 def test_transport_empty_packet(server: Server):
     transport, connection = connected_transport(server)

--- a/tests/test_transport_network.py
+++ b/tests/test_transport_network.py
@@ -1,0 +1,86 @@
+
+import pytest
+import RFXtrx
+
+import socket
+import dataclasses
+import threading
+
+
+@pytest.fixture(name="server_socket")
+def fixture_server_socket():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  
+    sock.bind(('127.0.0.1', 0))
+    sock.listen(1)
+    try:
+        yield sock
+    finally:
+        sock.close()
+
+@dataclasses.dataclass
+class Server:
+    address: tuple
+    connections: list[socket.socket]
+    event = threading.Event()
+
+@pytest.fixture(name="server")
+def fixture_server(server_socket: socket.socket):
+
+    server = Server(address=server_socket.getsockname(), connections=[])
+
+    def runner():
+        while True:
+            try:
+                connection, address = server_socket.accept()
+                server.connections.append(connection)
+                server.event.set()
+            except socket.error:
+                return
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server_socket.close()
+        for connection in server.connections:
+            connection.close()
+        thread.join()
+
+def connected_transport(server: Server):
+    server.event.clear()
+    transport = RFXtrx.PyNetworkTransport(server.address)
+    transport.sock.settimeout(10)
+    assert server.event.wait(10)
+    return transport, server.connections[-1]
+
+def test_transport_shutdown_between_packet(server: Server):
+    transport, connection = connected_transport(server)
+    connection.sendall(bytes([0x09, 0x03, 0x01, 0x04, 0x28, 0x0a, 0xb7, 0x66, 0x04, 0x70]))
+    connection.shutdown(socket.SHUT_RDWR)
+
+    pkt = transport.receive_blocking()
+    assert isinstance(pkt, RFXtrx.SensorEvent)
+    with pytest.raises(RFXtrx.RFXtrxTransportError):
+        transport.receive_blocking()
+
+def test_transport_shutdown_mid_packet(server: Server):
+    transport, connection = connected_transport(server)
+    connection.sendall(bytes([0x09, 0x03, 0x01, 0x04]))
+    connection.shutdown(socket.SHUT_RDWR)
+
+    with pytest.raises(RFXtrx.RFXtrxTransportError):
+        transport.receive_blocking()
+
+def test_transport_close_mid_packet(server: Server):
+    transport, connection = connected_transport(server)
+    connection.sendall(bytes([0x09, 0x03, 0x01, 0x04]))
+    connection.close()
+
+    with pytest.raises(RFXtrx.RFXtrxTransportError):
+        transport.receive_blocking()
+
+def test_transport_empty_packet(server: Server):
+    transport, connection = connected_transport(server)
+    connection.sendall(bytes([0x00]))
+
+    assert transport.receive_blocking() is None

--- a/tests/test_transport_network.py
+++ b/tests/test_transport_network.py
@@ -53,6 +53,7 @@ def connected_transport(server: Server):
     server.event.clear()
     transport = RFXtrx.PyNetworkTransport(server.address)
     transport.sock.settimeout(10)
+    transport.connect()
     assert server.event.wait(10)
     return transport, server.connections[-1]
 

--- a/tests/test_transport_network.py
+++ b/tests/test_transport_network.py
@@ -5,7 +5,7 @@ import RFXtrx
 import socket
 import dataclasses
 import threading
-
+from typing import Tuple, List
 
 @pytest.fixture(name="server_socket")
 def fixture_server_socket():
@@ -19,8 +19,8 @@ def fixture_server_socket():
 
 @dataclasses.dataclass
 class Server:
-    address: tuple
-    connections: list[socket.socket]
+    address: Tuple
+    connections: List[socket.socket]
     event = threading.Event()
 
 @pytest.fixture(name="server")

--- a/tests/test_transport_network.py
+++ b/tests/test_transport_network.py
@@ -11,6 +11,7 @@ from typing import Tuple, List
 def fixture_server_socket():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  
     sock.bind(('127.0.0.1', 0))
+    sock.settimeout(1)
     sock.listen(1)
     try:
         yield sock
@@ -34,6 +35,8 @@ def fixture_server(server_socket: socket.socket):
                 connection, address = server_socket.accept()
                 server.connections.append(connection)
                 server.event.set()
+            except socket.timeout:
+                continue
             except socket.error:
                 return
     thread = threading.Thread(target=runner, daemon=True)


### PR DESCRIPTION
Avoid handling reconnect inside transports. Signal lost connections via the event system instead to allow user to manage the reconnections.

- Remove reconnection logic in favor of user handling that
- Handle a socket shutdown leading to 100% cpu uage
- Split Connect from Transport construction
- Split connect() effects and errors from class initializers to allow easier cleanup